### PR TITLE
Update python wrappers

### DIFF
--- a/simcoon-python-builder/include/simcoon/python_wrappers/Libraries/Continuum_mechanics/hyperelastic.hpp
+++ b/simcoon-python-builder/include/simcoon/python_wrappers/Libraries/Continuum_mechanics/hyperelastic.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+namespace simpy{
+    
+//This function returns the isochoric invariants from b
+pybind11::array_t<double> isochoric_invariants(const pybind11::array_t<double> &input, const double &J=0., const bool &copy=true);
+
+//This function returns the isochoric principale stretches from b
+pybind11::array_t<double> isochoric_pstretch(const pybind11::array_t<double> &input, const std::string &input_tensor="V", const double &J=0., const bool &copy=true);
+
+} //namespace simpy

--- a/simcoon-python-builder/include/simcoon/python_wrappers/Libraries/Continuum_mechanics/objective_rates.hpp
+++ b/simcoon-python-builder/include/simcoon/python_wrappers/Libraries/Continuum_mechanics/objective_rates.hpp
@@ -7,7 +7,7 @@ namespace simpy{
 //This function computes the gradient of displacement (Lagrangian) from the deformation gradient tensor
 pybind11::tuple logarithmic(const pybind11::array_t<double> &F0, const pybind11::array_t<double> &F1, const double &DTime, const bool &copy=true);
 pybind11::tuple logarithmic_R(const pybind11::array_t<double> &F0, const pybind11::array_t<double> &F1, const double &DTime, const bool &copy=true);
-pybind11::tuple objective_rate(const std::string &corate_name, const pybind11::array_t<double> &F0, const pybind11::array_t<double> &F1, const double &DTime, const bool &return_de);
+pybind11::tuple objective_rate(const std::string &corate_name, const pybind11::array_t<double> &F0, const pybind11::array_t<double> &F1, const double &DTime, const bool &return_de, const unsigned int &n_threads);
 pybind11::array_t<double> Delta_log_strain(const pybind11::array_t<double> &D, const pybind11::array_t<double> &Omega, const double &DTime, const bool &copy=true);
 pybind11::array_t<double> Lt_convert(const pybind11::array_t<double> &Lt, const pybind11::array_t<double> &F, const pybind11::array_t<double> &stress, const std::string &converter_key);
 

--- a/simcoon-python-builder/include/simcoon/python_wrappers/Libraries/Continuum_mechanics/umat.hpp
+++ b/simcoon-python-builder/include/simcoon/python_wrappers/Libraries/Continuum_mechanics/umat.hpp
@@ -5,5 +5,5 @@ namespace py=pybind11;
 using namespace std;
 
 namespace simpy {
-	py::tuple launch_umat(const std::string& umat_name_py, const py::array_t<double> &etot_py, const py::array_t<double> &Detot_py, const py::array_t<double> &sigma_py, const py::array_t<double> &DR_py, const py::array_t<double> &props_py, const py::array_t<double> &statev_py, const float Time, const float DTime, const py::array_t<double> &Wm_py, const std::optional<py::array_t<double>> &T_py);
+	py::tuple launch_umat(const std::string& umat_name_py, const py::array_t<double> &etot_py, const py::array_t<double> &Detot_py, const py::array_t<double> &sigma_py, const py::array_t<double> &DR_py, const py::array_t<double> &props_py, const py::array_t<double> &statev_py, const float Time, const float DTime, const py::array_t<double> &Wm_py, const std::optional<py::array_t<double>> &T_py, const unsigned int &n_threads);
 }

--- a/simcoon-python-builder/src/python_wrappers/Libraries/Continuum_mechanics/hyperelastic.cpp
+++ b/simcoon-python-builder/src/python_wrappers/Libraries/Continuum_mechanics/hyperelastic.cpp
@@ -1,0 +1,108 @@
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+#include <carma>
+#include <armadillo>
+
+
+#include <simcoon/Continuum_mechanics/Functions/hyperelastic.hpp>
+#include <simcoon/Continuum_mechanics/Functions/transfer.hpp>
+#include <simcoon/python_wrappers/Libraries/Continuum_mechanics/hyperelastic.hpp>
+
+using namespace std;
+using namespace arma;
+namespace py=pybind11;
+
+namespace simpy {
+
+//This function returns the isochoric invariants
+py::array_t<double> isochoric_invariants(const py::array_t<double> &input, const double &J, const bool &copy) {
+
+    if(input.ndim() == 1) {
+        if(input.size() == 3) {
+            vec lambdas = carma::arr_to_col(input);
+            vec t = simcoon::isochoric_invariants(lambdas, J);
+            return carma::col_to_arr(t, copy);            
+        }
+        else if(input.size() == 6) {
+            vec vec_input = carma::arr_to_col(input);
+            mat b = simcoon::v2t_strain(vec_input);
+            vec t = simcoon::isochoric_invariants(b, J);
+            return carma::col_to_arr(t, copy);            
+        }
+        else 
+            throw std::invalid_argument("Invalid size of the one-dimensional array. Expected 3 (from principal stretches) or 6 (from left Cauchy-Green tensor in Voigt notation)");
+        }                
+    if(input.ndim() == 2) {        
+        if((input.shape(0) == 3)&&(input.shape(1) == 3)) {
+            mat b = carma::arr_to_mat(input);
+            vec t = simcoon::isochoric_invariants(b, J);
+            return carma::col_to_arr(t, copy);                         
+        }        
+        else if((input.shape(0) == 6)&&(input.shape(1) == 1)) {
+            mat mat_input = carma::arr_to_mat(input);            
+            mat sim_input = simcoon::v2t_strain(mat_input.as_col());
+            vec t = simcoon::isochoric_invariants(sim_input, J);
+            return carma::col_to_arr(t, copy);            
+        }
+        else {
+            throw std::invalid_argument("Invalid size of the two-dimensional array. Expected a 3x3 array or a 6x1 array considering Voigt notation");
+        }         
+    }
+}
+
+py::array_t<double> isochoric_pstretch(const py::array_t<double> &input, const std::string &input_tensor, const double &J, const bool &copy) {
+
+    if(input.ndim() == 1) {
+        if(input.size() == 6) {
+            vec vec_input = carma::arr_to_col(input);
+            if(input_tensor == "b") {
+                mat b = simcoon::v2t_strain(vec_input);
+                vec t = simcoon::isochoric_pstretch_from_b(b);                
+                return carma::col_to_arr(t, copy);                            
+            }
+            else if(input_tensor == "V" || input_tensor == "v") {
+                mat V = simcoon::v2t_strain(vec_input);
+                vec t = simcoon::isochoric_pstretch_from_V(V);
+                return carma::col_to_arr(t, copy);                            
+            }
+            else {
+                throw std::invalid_argument("Invalid input string to describe the input vector: it should be *b* for left Cauchy-Green tensor or *v* or *V* for Eulerian stretch tensor");                
+            }
+        }
+        else {
+            throw std::invalid_argument("Invalid size of the one-dimensional array. Expected 3 (from principal stretches) or 6 (from left Cauchy-Green tensor in Voigt notation)");
+        }
+    }                
+    if(input.ndim() == 2) {        
+        mat mat_input = carma::arr_to_mat(input);
+        if((input.shape(0) == 3)&&(input.shape(1) == 3)) {
+            if(input_tensor == "b") {
+                vec t = simcoon::isochoric_pstretch_from_b(mat_input);                
+                return carma::col_to_arr(t, copy);                            
+            }
+            else if(input_tensor == "V" || input_tensor == "v") {
+                vec t = simcoon::isochoric_pstretch_from_V(mat_input);
+                return carma::col_to_arr(t, copy);                            
+            }            
+        }        
+        else if((input.shape(0) == 6)&&(input.shape(1) == 1)) {
+            mat sim_input = simcoon::v2t_strain(mat_input.as_col());
+            if(input_tensor == "b") {
+                vec t = simcoon::isochoric_pstretch_from_b(sim_input);                
+                return carma::col_to_arr(t, copy);                            
+            }
+            else if(input_tensor == "V" || input_tensor == "v") {
+                vec t = simcoon::isochoric_pstretch_from_V(sim_input);
+                return carma::col_to_arr(t, copy);                            
+            }            
+        }
+        else {
+            throw std::invalid_argument("Invalid size of the two-dimensional array. Expected a 3x3 array or a 6x1 array considering Voigt notation");
+        }         
+    }
+}
+
+
+} //namepsace simpy

--- a/simcoon-python-builder/src/python_wrappers/Libraries/Continuum_mechanics/objective_rates.cpp
+++ b/simcoon-python-builder/src/python_wrappers/Libraries/Continuum_mechanics/objective_rates.cpp
@@ -47,7 +47,7 @@ py::tuple logarithmic_R(const py::array_t<double> &F0, const py::array_t<double>
 
 
 //This function computes the logarithmic strain velocity and the logarithmic spin, along with the correct rotation increment
-py::tuple objective_rate(const std::string& corate_name, const py::array_t<double> &F0, const py::array_t<double> &F1, const double &DTime, const bool &return_de) {
+py::tuple objective_rate(const std::string& corate_name, const py::array_t<double> &F0, const py::array_t<double> &F1, const double &DTime, const bool &return_de, const unsigned int &n_threads) {
     std::map<string, int> list_corate;
     list_corate = { {"jaumann",0},{"green_naghdi",1},{"logarithmic",2},{"logarithmic_R",3}, {"gn",1},{"log",2},{"log_R",3}};
 	int corate = list_corate[corate_name];

--- a/simcoon-python-builder/src/python_wrappers/Libraries/Continuum_mechanics/umat.cpp
+++ b/simcoon-python-builder/src/python_wrappers/Libraries/Continuum_mechanics/umat.cpp
@@ -55,7 +55,7 @@ namespace py=pybind11;
 
 namespace simpy {
 	
-	py::tuple launch_umat(const std::string& umat_name_py, const py::array_t<double> &etot_py, const py::array_t<double> &Detot_py, const py::array_t<double> &sigma_py, const py::array_t<double> &DR_py, const py::array_t<double> &props_py, const py::array_t<double> &statev_py, const float Time, const float DTime, const py::array_t<double> &Wm_py, const std::optional<py::array_t<double>> &T_py){
+	py::tuple launch_umat(const std::string& umat_name_py, const py::array_t<double> &etot_py, const py::array_t<double> &Detot_py, const py::array_t<double> &sigma_py, const py::array_t<double> &DR_py, const py::array_t<double> &props_py, const py::array_t<double> &statev_py, const float Time, const float DTime, const py::array_t<double> &Wm_py, const std::optional<py::array_t<double>> &T_py, const unsigned int &n_threads){
 		//Get the id of umat
 
 		std::map<string, int> list_umat;
@@ -244,7 +244,7 @@ namespace simpy {
 			vec props(ncomp);
 
 			int max_threads = omp_get_max_threads();
-			omp_set_num_threads(4);
+			omp_set_num_threads(n_threads);
 			py::gil_scoped_release release;
 
 			#ifdef _OPENMP
@@ -289,6 +289,10 @@ namespace simpy {
 			omp_set_num_threads(max_threads);			
 			return py::make_tuple(carma::mat_to_arr(list_sigma, false), carma::mat_to_arr(list_statev, false), carma::mat_to_arr(list_Wm, false), carma::cube_to_arr(Lt, false));
 		}
+		else {
+            throw std::invalid_argument("the dimension of etot_py is not correct (either 1 or 2)");			
+		}
+
 	}
 }
 
@@ -322,7 +326,7 @@ namespace simpy {
 					arguments_type = 4;
 					break;
 				}
-/*				case 5: {
+				case 5: {
 					umat_function = &simcoon::umat_plasticity_iso_CCP;
 					arguments_type = 1;
 					//simcoon::umat_plasticity_iso_CCP(etot, Detot, sigma, Lt, L, sigma_in, DR, nprops, props, nstatev, statev, T, DT, Time, DTime, Wm, Wm_r, Wm_ir, Wm_d, ndi, nshr, start, solver_type, tnew_dt);

--- a/simcoon-python-builder/src/python_wrappers/boostpython_smartplus_wrappers.cpp
+++ b/simcoon-python-builder/src/python_wrappers/boostpython_smartplus_wrappers.cpp
@@ -9,6 +9,7 @@
 #include <simcoon/python_wrappers/Libraries/Continuum_mechanics/stress.hpp>
 #include <simcoon/python_wrappers/Libraries/Continuum_mechanics/criteria.hpp>
 #include <simcoon/python_wrappers/Libraries/Continuum_mechanics/damage.hpp>
+#include <simcoon/python_wrappers/Libraries/Continuum_mechanics/hyperelastic.hpp>
 #include <simcoon/python_wrappers/Libraries/Continuum_mechanics/recovery_props.hpp>
 #include <simcoon/python_wrappers/Libraries/Continuum_mechanics/Leff.hpp>
 #include <simcoon/python_wrappers/Libraries/Continuum_mechanics/kinematics.hpp>
@@ -135,7 +136,7 @@ PYBIND11_MODULE(simmit, m) {
     m.def("logarithmic", &logarithmic, "F0"_a, "F1"_a, "DTime"_a, "copy"_a=true, "This function computes the logarithmic strain velocity and the logarithmic spin, along with the correct rotation increment");
     m.def("logarithmic_R", &logarithmic_R, "F0"_a, "F1"_a, "DTime"_a, "copy"_a=true, "This function computes the logarithmic strain velocity and the Green-Naghdi spin, along with the correct rotation increment");    
     m.def("Delta_log_strain", &Delta_log_strain, "D"_a, "Omega"_a, "DTime"_a, "copy"_a=true, "This function computes the gradient of displacement (Eulerian) from the deformation gradient tensor");
-    m.def("objective_rate", &objective_rate, "corate_name"_a,"F0"_a, "F1"_a, "dtime"_a, "return_de"_a=false, "This function computes the strain velocity and the spin, along with the correct rotation increment for the specified objective erivative");
+    m.def("objective_rate", &objective_rate, "corate_name"_a,"F0"_a, "F1"_a, "dtime"_a, "return_de"_a=false, "n_threads"_a = 4, "This function computes the strain velocity and the spin, along with the correct rotation increment for the specified objective erivative");
     m.def("Lt_convert", &Lt_convert, "Lt"_a, "F"_a, "stress"_a, "converter_key"_a);
 
     //register the damage library
@@ -143,6 +144,10 @@ PYBIND11_MODULE(simmit, m) {
     m.def("damage_kachanov", &damage_kachanov, "stress"_a, "strain"_a, "damage"_a, "A0"_a, "r"_a, "criterion"_a, "This function returns damage evolution (/dt) considering Kachanov's creep damage law");
     m.def("damage_miner", &damage_miner, "S_max"_a, "S_mean"_a, "S_ult"_a, "b"_a, "B0"_a, "beta"_a, "Sl_0"_a = 0., "This function returns the constant damage evolution (/dN) considering Woehler- Miner's damage law");
     m.def("damage_manson", &damage_manson, "S_amp"_a, "C2"_a, "gamma2"_a, "This function returns the constant damage evolution (/dN) considering Coffin-Manson's damage law");
+
+    //register the hyperelastic library
+    m.def("isochoric_invariants", &isochoric_invariants, "input"_a, "J"_a=0., "copy"_a=true, "This function computes the isochoric invariants");
+    m.def("isochoric_pstretch", &isochoric_pstretch, "input"_a, "input_tensor"_a="V", "J"_a=0., "copy"_a=true, "This function computes the isochoric invariants");    
 
     //register the transfer library
     m.def("v2t_strain", &v2t_strain, "input"_a, "copy"_a=true, "This function transforms the strain Voigt vector into a 3*3 strain matrix");
@@ -207,7 +212,7 @@ PYBIND11_MODULE(simmit, m) {
     m.def("stress_convert", &stress_convert, "sigma"_a, "F"_a, "converter_key"_a, "J"_a=0., "copy"_a=true, "Provides the first Piola Kirchoff stress tensor from the Cauchy stress tensor");
 
     //umat
-    m.def("umat", &launch_umat, "umat_name"_a, "etot"_a, "Detot"_a, "sigma"_a, "DR"_a, "props"_a, "statev"_a, "time"_a, "dtime"_a, "Wm"_a, "temp"_a = pybind11::none());
+    m.def("umat", &launch_umat, "umat_name"_a, "etot"_a, "Detot"_a, "sigma"_a, "DR"_a, "props"_a, "statev"_a, "time"_a, "dtime"_a, "Wm"_a, "temp"_a = pybind11::none(), "n_threads"_a = 4);
 
     // Register the from-python converters for read and solver
     m.def("read_matprops", &read_matprops);
@@ -217,4 +222,8 @@ PYBIND11_MODULE(simmit, m) {
     // Register the from-python converters for ODF functions
     m.def("get_densities_ODF", &get_densities_ODF);
     m.def("ODF_discretization", &ODF_discretization);
+
+    // Register the from-python converters for identification
+    m.def("identification", &identification);
+
 }


### PR DESCRIPTION
This PR adds the wrappers of the last updates:

- the identification module has moved to 'simmit'
- multithreading with openMP
- adding first hyperelasticity functions 