### PR TITLE
1.9.5

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: simcoon
-  version: 1.9.4
+  version: 1.9.5
 
 source:
   git_url: https://github.com/3MAH/simcoon.git
-  #git_tag: 1.9.0
+  #git_tag: 1.9.5
 
 build:
   number: 0

--- a/python-setup/setup.py
+++ b/python-setup/setup.py
@@ -9,7 +9,7 @@ else:
 
 setup(
     name="simcoon",
-    version="1.9.4",
+    version="1.9.5",
     description="Simulation in Mechanics and Materials: Interactive Tools",
     author="Yves Chemisky",
     author_email="yves.chemisky@gmail.com",


### PR DESCRIPTION
Switch to 1.9.5 mainly due to major changes in the CI. Side effects on the installation process which justify a subversion