### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,32 +130,6 @@ jobs:
           name: test-logs-Python-OSX
           path: simcoon-python-builder/build/Testing/Temporary/LastTest.log                      
 
-  WindowsSimcoonOnly:
-    name: WindowsSimcoonOnly
-    runs-on: "windows-latest"
-    steps:
-      - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniconda-version: "latest"
-          activate-environment: foo
-          environment-file: environment_win.yml    
-
-      - name: Build for Windows
-        shell: pwsh
-        run: |
-          cmake -S . -B build `
-              -DCMAKE_BUILD_TYPE=Release `
-              -DCMAKE_INSTALL_PREFIX="$env:CONDA_PREFIX/Library" `
-              -DUSE_CARMA=False `
-              -Wno-dev
-          cmake --build build --config Release
-          cmake --install build
-
-      - name: Tests
-        shell: pwsh
-        run: ctest --test-dir build -C Release --output-on-failure -VV
-
   Windows:
     name: Windows
     runs-on: "windows-latest"
@@ -176,6 +150,10 @@ jobs:
               -Wno-dev
           cmake --build build --config Release
           cmake --install build
+
+      - name: Tests
+        shell: pwsh
+        run: ctest --test-dir build -C Release --output-on-failure -VV
 
       - name: Build Python lib
         shell: pwsh


### PR DESCRIPTION
This pull request updates the GitHub Actions CI workflow configuration for Windows builds: It uses the PR #38 to allows the test of GTest using Simcoon with armadillo compiled with Carma in Windows.

* Removed the `WindowsSimcoonOnly` job
* Adding GTest tests to the build `Windows` 