### PR TITLE
Use Netlib BLAS/LAPACK and remove MSVC override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,9 +127,6 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 enable_testing()
 
 # Find dependencies
-if(MSVC)
-  set(BLA_PREFER_PKGCONFIG TRUE)
-endif()
 
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)

--- a/environment_win.yml
+++ b/environment_win.yml
@@ -6,9 +6,8 @@ channels:
 
 dependencies:
   - pkg-config
-  - libblas * *mkl
-  - liblapack * *mkl
-  - mkl
+  - libblas * *netlib
+  - liblapack * *netlib
   - cmake>=3.30
   - python
   - numpy>=1.24


### PR DESCRIPTION
Remove the MSVC-specific BLA_PREFER_PKGCONFIG conditional from CMakeLists.txt so pkg-config preference is no longer forced only on MSVC. Update environment_win.yml to use libblas/liblapack from the netlib channel and remove the mkl package, keeping pkg-config, cmake, python, and numpy dependencies. These changes align Windows environment deps with Netlib BLAS/LAPACK and simplify the build configuration.