### PR TITLE
Fix wheel for windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "simcoon"
-version = "1.11.1"
+version = "1.11.2"
 description = "Simulation in Mechanics and Materials: Interactive Tools - A library for the simulation of multiphysics systems and heterogeneous materials"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}
@@ -194,5 +194,7 @@ before-all = "vcpkg install armadillo:x64-windows openblas:x64-windows"
 # Point CMake to vcpkg
 environment = { CMAKE_TOOLCHAIN_FILE = "C:/vcpkg/scripts/buildsystems/vcpkg.cmake" }
 
-# Skip wheel repair — CMake installs all needed DLLs directly into the wheel
-repair-wheel-command = ""
+# delvewheel bundles vcpkg-installed DLLs (Armadillo, OpenBLAS) and the
+# MSVC C++/OpenMP runtimes into the wheel so it is self-contained.
+before-build = "pip install delvewheel"
+repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel} --add-path C:/vcpkg/installed/x64-windows/bin"


### PR DESCRIPTION
This pull request updates the `pyproject.toml` configuration to improve Windows wheel packaging and increment the project version. The most notable changes are related to making the built wheel self-contained by bundling required DLLs and runtimes, and updating the package version.

Packaging improvements:

* Added `delvewheel` as a build dependency and updated the `repair-wheel-command` to use `delvewheel` for bundling vcpkg-installed DLLs (Armadillo, OpenBLAS) and MSVC C++/OpenMP runtimes, ensuring the wheel is self-contained on Windows.

Version update:

* Incremented the package version from `1.11.1` to `1.11.2` in `pyproject.toml`.