### PR TITLE
Standardize docstring heading style in examples [skipci]

### DIFF
--- a/examples/mechanical/ELISO.py
+++ b/examples/mechanical/ELISO.py
@@ -1,6 +1,6 @@
 """
 Isotropic elasticity examples
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=============================
 """
 
 import numpy as np

--- a/examples/mechanical/ELIST.py
+++ b/examples/mechanical/ELIST.py
@@ -1,6 +1,6 @@
 """
 Transversely Isotropic Elasticity Example
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=========================================
 """
 
 import numpy as np

--- a/examples/mechanical/ELORT.py
+++ b/examples/mechanical/ELORT.py
@@ -1,6 +1,6 @@
 """
 Orthotropic Elasticity Example
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+==============================
 """
 
 import numpy as np

--- a/examples/thermomechanical/ELISO.py
+++ b/examples/thermomechanical/ELISO.py
@@ -1,6 +1,6 @@
 """
 Isotropic elasticity (thermomechanical)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=======================================
 """
 
 import numpy as np

--- a/examples/thermomechanical/ELIST.py
+++ b/examples/thermomechanical/ELIST.py
@@ -1,6 +1,6 @@
 """
 Transversely isotropic elasticity (thermomechanical)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+====================================================
 """
 
 import numpy as np

--- a/examples/thermomechanical/ELORT.py
+++ b/examples/thermomechanical/ELORT.py
@@ -1,6 +1,6 @@
 """
 Orthotropic elasticity (thermomechanical)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=========================================
 """
 
 import numpy as np


### PR DESCRIPTION
Replace tilde (~) underlines with equals (=) underlines in module docstrings for consistency across example scripts. Updated ELISO.py, ELIST.py, and ELORT.py in both examples/mechanical and examples/thermomechanical to use a uniform '=' header underline for improved readability and formatting.