### PR TITLE
Feature/kin ident

### DIFF
--- a/examples/analysis/hyperelastic_parameter_identification.py
+++ b/examples/analysis/hyperelastic_parameter_identification.py
@@ -9,6 +9,14 @@ model parameters from Treloar's classical rubber elasticity experiments.
 **Optimization**: scipy.optimize.differential_evolution (global optimizer)
 **Cost function**: Mean Squared Error on stress (sklearn.metrics.mean_squared_error)
 **Forward model**: simcoon hyperelastic stress functions
+
+.. seealso::
+
+   ``examples/hyperelasticity/hyperelastic_umat_identification.py`` solves the
+   same problem with the deployable ``MOORI`` UMAT (via ``sim.solver``) and
+   Simcoon's identification API (``sim.identification`` + ``sim.calc_cost``).
+   This analytical version is fast and exposes the physics; that one exercises
+   the production UMAT and the library cost function.
 """
 
 import numpy as np

--- a/examples/hyperelasticity/data/path_ET_id.txt
+++ b/examples/hyperelasticity/data/path_ET_id.txt
@@ -1,0 +1,33 @@
+#Initial_temperature
+293.5
+#Number_of_blocks
+1
+
+#Block
+1
+#Loading_type
+1
+#Control_type(NLGEOM)
+4
+#Repeat
+1
+#Steps
+1
+
+#Mode
+1
+#Dn_init 1.
+#Dn_mini 1.
+#Dn_inc 0.02
+#time
+5.
+#prescribed_mechanical_state
+E 4.6
+S 0. E 4.6
+S 0. S 0. S 0.
+#Rotation
+0. 0. 0.
+0. 0. 0.
+0. 0. 0.
+#prescribed_temperature_state
+T 290

--- a/examples/hyperelasticity/data/path_PS_id.txt
+++ b/examples/hyperelasticity/data/path_PS_id.txt
@@ -1,0 +1,33 @@
+#Initial_temperature
+293.5
+#Number_of_blocks
+1
+
+#Block
+1
+#Loading_type
+1
+#Control_type(NLGEOM)
+4
+#Repeat
+1
+#Steps
+1
+
+#Mode
+1
+#Dn_init 1.
+#Dn_mini 1.
+#Dn_inc 0.02
+#time
+5.
+#prescribed_mechanical_state
+E 5.2
+S 0. S 0.
+S 0. S 0. E 1.0
+#Rotation
+0. 0. 0.
+0. 0. 0.
+0. 0. 0.
+#prescribed_temperature_state
+T 290

--- a/examples/hyperelasticity/data/path_UT_id.txt
+++ b/examples/hyperelasticity/data/path_UT_id.txt
@@ -1,0 +1,33 @@
+#Initial_temperature
+293.5
+#Number_of_blocks
+1
+
+#Block
+1
+#Loading_type
+1
+#Control_type(NLGEOM)
+4
+#Repeat
+1
+#Steps
+1
+
+#Mode
+1
+#Dn_init 1.
+#Dn_mini 1.
+#Dn_inc 0.02
+#time
+5.
+#prescribed_mechanical_state
+E 8.
+S 0. S 0.
+S 0. S 0. S 0.
+#Rotation
+0. 0. 0.
+0. 0. 0.
+0. 0. 0.
+#prescribed_temperature_state
+T 290

--- a/examples/hyperelasticity/hyperelastic_umat_identification.py
+++ b/examples/hyperelasticity/hyperelastic_umat_identification.py
@@ -1,0 +1,286 @@
+"""
+Mooney-Rivlin identification with the MOORI UMAT and the simcoon API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Identify the Mooney-Rivlin parameters :math:`C_{10}, C_{01}` from Treloar's
+rubber data using simcoon "as it ships":
+
+- **Forward model**: the real ``MOORI`` hyperelastic **UMAT**, driven by
+  :func:`simcoon.solver` exactly as it would run inside a finite-element
+  analysis (this is the same forward model as ``HYPER_umat.py``). The
+  transverse-equilibrium condition (zero stress on the free faces) is handled
+  *inside* the solver through mixed control, so there is no hand-written
+  ``fsolve`` loop.
+- **Optimizer**: :func:`simcoon.identification` (a thin wrapper around
+  ``scipy.optimize.differential_evolution``) reading bounds from
+  :class:`simcoon.parameter.Parameter` objects.
+- **Cost**: :func:`simcoon.calc_cost` with the ``"nmse_per_response"`` metric.
+
+This is the library-native counterpart of
+``examples/analysis/hyperelastic_parameter_identification.py``, which solves
+the *same* problem with a hand-rolled analytical stress and a manual
+``scipy``/``sklearn`` cost. Both are kept on purpose: the analytical version is
+fast and exposes the physics; this one exercises the deployable UMAT and the
+identification API. See the cost-function section for the exact correspondence.
+
+**Loading / control.** Each Treloar test is a homogeneous diagonal stretch run
+under **Biot control** (``#Control_type(NLGEOM) 4``): the prescribed "strain"
+is the stretch :math:`U_{11}` itself and the work-conjugate Biot stress is set
+to zero on the free faces. That is why the load-path files read ``E 4.6`` for
+equibiaxial (:math:`\\lambda \\approx 4.6`) and hold the constrained pure-shear
+direction at ``E 1.0`` (:math:`\\lambda = 1`).
+"""
+
+# sphinx_gallery_thumbnail_number = 1
+
+import os
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+import simcoon as sim
+from simcoon.parameter import Parameter
+from simcoon.identify import identification, calc_cost
+
+
+###############################################################################
+# Configuration
+# -------------
+#
+# The Mooney-Rivlin strain energy is
+#
+# .. math::
+#    W = C_{10}(\bar{I}_1 - 3) + C_{01}(\bar{I}_2 - 3)
+#        + \kappa\,(J\ln J - J + 1),
+#
+# and the ``MOORI`` UMAT takes the props vector ``[C10, C01, kappa]``. We
+# identify :math:`C_{10}` and :math:`C_{01}` and keep the bulk modulus
+# :math:`\kappa` fixed (near-incompressible rubber).
+
+UMAT_NAME = "MOORI"
+NSTATEV = 1
+SOLVER_TYPE = 0          # Newton
+CORATE_TYPE = 2          # same objective rate as HYPER_umat.py
+KAPPA = 10000.0          # fixed bulk modulus [MPa]
+
+# Treloar loading cases: label, load-path file, and the matching Treloar.txt
+# columns (stretch / first Piola-Kirchhoff stress). The ``*_id`` paths use a
+# coarser increment than HYPER_umat's, fast enough for many optimizer calls.
+CASES = [
+    ("UT", "path_UT_id.txt", "lambda_1", "P1_MPa"),   # uniaxial tension
+    ("PS", "path_PS_id.txt", "lambda_2", "P2_MPa"),   # pure shear
+    ("ET", "path_ET_id.txt", "lambda_3", "P3_MPa"),   # equibiaxial tension
+]
+
+# Columns of the solver ``*_global-0.txt`` output produced by
+# ``data/output.dat`` (strain_type 4 = stretch U, stress_type 1 = PK1):
+# the loading stretch lambda_1 and the nominal stress P_11.
+LAMBDA_COL = 10
+PK1_COL = 11
+
+# Reference parameters (Steinmann et al., 2012) for the final comparison.
+LIT = {"UT": (0.2588, -0.0449), "PS": (0.2348, -0.0650), "ET": (0.1713, 0.0047)}
+
+
+def make_params():
+    """Fresh Parameter pair (identification writes the result back into
+    ``.value``, so every fit gets its own)."""
+    # Same search box as the analytical example, for a fair comparison.
+    return [
+        Parameter(0, bounds=(0.01, 2.0), key="@C10"),   # C10 [MPa]
+        Parameter(1, bounds=(-1.0, 1.0), key="@C01"),   # C01 [MPa]
+    ]
+
+
+def build_props(x):
+    """MOORI props vector ``[C10, C01, kappa]`` from the optimizer array."""
+    return np.array([x[0], x[1], KAPPA])
+
+
+###############################################################################
+# Forward model: the MOORI UMAT through ``sim.solver``
+# ---------------------------------------------------
+#
+# For one loading case we run the solver over the prescribed stretch ramp and
+# read the ``(lambda, P_11)`` trajectory straight from its global output.
+# Because the experimental points sit at specific stretches, we interpolate the
+# (smooth) model trajectory onto the experimental lambda values. A tab-file
+# replay, as in ``chaboche_cyclic_identification.py``, could hit the
+# experimental stretches exactly; interpolation keeps the load paths simple.
+
+
+def run_case(props, pathfile, outputfile, path_data, path_results):
+    """Run one solver call and return its ``(lambda, P_11)`` trajectory."""
+    sim.solver(
+        UMAT_NAME, props, NSTATEV,
+        0.0, 0.0, 0.0,                 # psi, theta, phi (no RVE rotation)
+        SOLVER_TYPE, CORATE_TYPE,
+        path_data, path_results,
+        pathfile, outputfile,
+    )
+    base = outputfile[:-4] if outputfile.endswith(".txt") else outputfile
+    out = np.loadtxt(os.path.join(path_results, f"{base}_global-0.txt"))
+    return out[:, LAMBDA_COL], out[:, PK1_COL]
+
+
+def model_pk1(lambda_exp, props, pathfile, outputfile, path_data, path_results):
+    """Model ``P_11`` sampled at the experimental stretches."""
+    lam, pk1 = run_case(props, pathfile, outputfile, path_data, path_results)
+    # Anchor the unstressed reference state so lambda = 1 maps to P_11 = 0.
+    lam = np.concatenate(([1.0], lam))
+    pk1 = np.concatenate(([0.0], pk1))
+    return np.interp(lambda_exp, lam, pk1)
+
+
+###############################################################################
+# Cost function: ``sim.calc_cost`` with NMSE-per-response
+# ------------------------------------------------------
+#
+# The analytical example
+# (``examples/analysis/hyperelastic_parameter_identification.py``) builds its
+# combined cost *by hand*: for each loading case it takes the
+# ``mean_squared_error`` and divides by the variance of the experimental data
+# (an NMSE), then sums the cases. That normalisation is exactly what
+# :func:`simcoon.calc_cost` provides via ``metric="nmse_per_response"`` — each
+# response (here the stress column of each test) is divided by its own sum of
+# squares before averaging, so UT, PS and ET contribute on an equal footing
+# despite their different stress magnitudes. We hand-rolled it there; we simply
+# call the library here.
+#
+# ``calc_cost`` expects one 2-D array of shape ``(n_points, n_responses)`` per
+# test; with a single stress response per test the arrays are ``(n_points, 1)``.
+
+
+def cost(x, jobs, path_data, path_results):
+    """NMSE-per-response cost over the loading cases in *jobs*.
+
+    *jobs* is a list of ``(name, pathfile, lambda_exp, P_exp)`` tuples.
+    """
+    props = build_props(x)
+    y_exp, y_num = [], []
+    for name, pathfile, lam_exp, P_exp in jobs:
+        try:
+            P_model = model_pk1(
+                lam_exp, props, pathfile, f"id_{name}.txt",
+                path_data, path_results,
+            )
+        except Exception:
+            return 1e12
+        y_exp.append(P_exp.reshape(-1, 1))
+        y_num.append(P_model.reshape(-1, 1))
+    return calc_cost(y_exp, y_num, metric="nmse_per_response")
+
+
+def identify(jobs, path_data, path_results, popsize=15, maxiter=25, seed=42):
+    """Run ``sim.identification`` over the given *jobs*; return ``([C10, C01],
+    final_cost)``."""
+    params = make_params()
+    result = identification(
+        cost, params,
+        args=(jobs, path_data, path_results),
+        seed=seed, popsize=popsize, maxiter=maxiter, tol=1e-6, disp=False,
+    )
+    return [p.value for p in params], result.fun
+
+
+###############################################################################
+# Driver
+# ------
+#
+# Two identification strategies, mirroring the analytical example:
+#
+# 1. **Individual** — one ``(C10, C01)`` pair fitted to each loading case.
+# 2. **Combined**   — a single pair fitted to all three cases at once.
+
+
+def main():
+    try:
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+    except NameError:
+        script_dir = os.getcwd()
+    os.chdir(script_dir)
+
+    path_data = "data"
+    path_results = "results"
+    os.makedirs(path_results, exist_ok=True)
+
+    df = pd.read_csv(
+        os.path.join("comparison", "Treloar.txt"),
+        sep=r"\s+", engine="python",
+        names=["lambda_1", "P1_MPa", "lambda_2", "P2_MPa", "lambda_3", "P3_MPa"],
+        header=0,
+    )
+
+    # Per-case experimental (lambda, P_11), NaNs dropped.
+    exp = {}
+    for name, _pf, lc, pc in CASES:
+        mask = ~df[lc].isna() & ~df[pc].isna()
+        exp[name] = (df.loc[mask, lc].values, df.loc[mask, pc].values)
+
+    print("=" * 66)
+    print(" MOONEY-RIVLIN IDENTIFICATION via the MOORI UMAT + simcoon API")
+    print(" forward: sim.solver | cost: sim.calc_cost(nmse_per_response)")
+    print("=" * 66)
+    for name, _pf, _lc, _pc in CASES:
+        lam, P = exp[name]
+        print(f"  {name}: {len(lam)} pts, lambda in [{lam.min():.2f}, {lam.max():.2f}]")
+
+    # ----- Individual fits ------------------------------------------------ #
+    print("\n" + "-" * 66)
+    print(" INDIVIDUAL FITS (one parameter set per loading case)")
+    print("-" * 66)
+    print(f"{'Case':<6}{'C10':>10}{'C01':>10}{'C10 lit.':>12}{'C01 lit.':>12}")
+    individual = {}
+    for name, pathfile, _lc, _pc in CASES:
+        lam_exp, P_exp = exp[name]
+        (c10, c01), _fun = identify(
+            [(name, pathfile, lam_exp, P_exp)], path_data, path_results
+        )
+        individual[name] = (c10, c01)
+        l10, l01 = LIT[name]
+        print(f"{name:<6}{c10:>10.4f}{c01:>10.4f}{l10:>12.4f}{l01:>12.4f}")
+
+    # ----- Combined fit --------------------------------------------------- #
+    print("\n" + "-" * 66)
+    print(" COMBINED FIT (single parameter set for UT + PS + ET)")
+    print("-" * 66)
+    jobs = [(n, pf, *exp[n]) for n, pf, _lc, _pc in CASES]
+    (c10_c, c01_c), cost_c = identify(jobs, path_data, path_results)
+    print(f"  C10 = {c10_c:.4f} MPa, C01 = {c01_c:.4f} MPa  "
+          f"(NMSE/response = {cost_c:.4e})")
+
+    # ----- Plot: individual (top) and combined (bottom) vs Treloar -------- #
+    fig, axes = plt.subplots(2, 3, figsize=(15, 9))
+    for col, (name, pathfile, _lc, _pc) in enumerate(CASES):
+        lam_exp, P_exp = exp[name]
+        for row, (c10, c01, tag) in enumerate([
+            (*individual[name], "individual"),
+            (c10_c, c01_c, "combined"),
+        ]):
+            ax = axes[row, col]
+            lam_m, pk1_m = run_case(
+                build_props([c10, c01]), pathfile,
+                f"plot_{name}_{tag}.txt", path_data, path_results,
+            )
+            ax.plot(lam_exp, P_exp, "o", ms=6, mfc="red", mec="black",
+                    label="Treloar")
+            ax.plot(lam_m, pk1_m, "-", lw=2, color="tab:blue",
+                    label=f"MOORI (C10={c10:.3f}, C01={c01:.3f})")
+            ax.set_xlabel(r"stretch $\lambda$")
+            ax.set_ylabel(r"$P_{11}$ [MPa]")
+            ax.set_title(f"{name} — {tag} fit")
+            ax.grid(True, alpha=0.3)
+            ax.legend(loc="upper left", fontsize=9)
+
+    fig.suptitle(
+        "Mooney-Rivlin identification with the MOORI UMAT + simcoon API\n"
+        "(top: per-case fits, bottom: combined fit)",
+        fontsize=13, fontweight="bold",
+    )
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/identification/README.rst
+++ b/examples/identification/README.rst
@@ -1,0 +1,19 @@
+Parameter identification examples
+-----------------------------------------------
+
+Below are examples illustrating Simcoon's parameter-identification workflow:
+calibrating constitutive-model parameters from experimental data with the
+identification API (``sim.identification`` and ``sim.calc_cost``) on top of the
+material-point solver and homogenization tools.
+
+This gallery contains examples demonstrating:
+
+- **Chaboche cyclic plasticity** - Identifying 7 elasto-plastic parameters (``EPCHA`` UMAT) from cyclic uniaxial tests, with an NMSE-per-response cost
+
+.. note::
+
+   Two related hyperelastic identification examples live in other galleries:
+   ``analysis/hyperelastic_parameter_identification.py`` (hand-rolled analytical
+   stress + manual ``scipy``/``sklearn`` cost) and
+   ``hyperelasticity/hyperelastic_umat_identification.py`` (the deployable
+   ``MOORI`` UMAT driven through ``sim.solver`` with the identification API).

--- a/include/simcoon/Continuum_mechanics/Functions/objective_rates.hpp
+++ b/include/simcoon/Continuum_mechanics/Functions/objective_rates.hpp
@@ -348,10 +348,11 @@ arma::mat Delta_log_strain_F(const arma::mat &D, const arma::mat &L, const doubl
  *  - **3** log_R: \f$ \mathbf{D}_e=\mathbf{A}^{R}\!:\!\mathbf{D} \f$, the R-corotational (Green-Naghdi)
  *    rate of \f$ \ln V \f$ integrated over the orthogonal frame; \f$ \mathbf{A}^{R} \f$ is PD and
  *    \f$ \epsilon\to\ln V \f$, so the F-reconstruction stays well posed.
- *  - **5** log_F: exact convected difference \f$ \ln V_1 - \mathbf{DF}\,\ln V_0\,\mathbf{DF}^{-1} \f$
- *    (mixed-control F-reconstruction stays well posed). The convected \f$ \mathbf{A}^{F}\!:\!\mathbf{D} \f$
- *    rate (upper-convected/Oldroyd of \f$ \ln V \f$, indefinite past \f$ \lambda=\sqrt{e} \f$) is used
- *    only in the F-prescribed (NLGEOM) branch, where no reconstruction is performed.
+ *  - **5** log_F: \f$ \mathbf{D}_e=\mathbf{A}^{F}\!:\!\mathbf{D} \f$, the convected (Oldroyd) rate of
+ *    \f$ \ln V \f$ integrated over the F-frame (\f$ \mathbf{DF} \f$ built from the velocity gradient
+ *    L, carried in @p Omega). \f$ \mathbf{A}^{F} \f$ now recovers \f$ \ln V \f$ like \f$ \mathbf{A}^{R} \f$
+ *    (the earlier \f$ -\tfrac12\ln(b_i b_j) \f$ indefinite term was removed). A genuine rate, used for
+ *    ALL control_types so inelastic UMATs integrate from a real \f$ \mathbf{D}_e \f$.
  *  - **0/1/4** Jaumann / Green-Naghdi / Truesdell (\f$ \mathbf{A}=\mathbf{I} \f$): \f$ \mathbf{D}_e=\mathbf{D} \f$.
  *
  * Only affects rate-form/hypoelastic UMATs that accumulate \f$ \epsilon \f$; hyperelastic boxes read
@@ -359,6 +360,16 @@ arma::mat Delta_log_strain_F(const arma::mat &D, const arma::mat &L, const doubl
  * @return the spatial logarithmic-strain increment for the chosen corate
 */
 arma::mat Delta_log_strain_corate(const arma::mat &F0, const arma::mat &F1, const arma::mat &DR, const arma::mat &D, const arma::mat &Omega, const double &DTime, const int &corate_type);
+
+/**
+ * @brief Corate spin dispatch: for the chosen objective rate, set the frame increment @p DR and the
+ *        rate of deformation @p D / spin (or velocity gradient L) @p Omega from @p F0, @p F1.
+ *        Single source of truth for the solver's control_type ladders (predictor + Newton-Raphson),
+ *        so every control_type (1..4, NLGEOM) dispatches the corate identically.
+ *  - 0 Jaumann, 1 Green-Naghdi, 2 logarithmic/XBM, 3 log_R (DR=R-rotation), 4 Truesdell (DR=DF),
+ *    5 log_F (DR=DF; @p Omega receives the velocity gradient L for the convected A^F:D rate).
+ */
+void corate_kinematics(const int &corate_type, arma::mat &DR, arma::mat &D, arma::mat &Omega, const arma::mat &F0, const arma::mat &F1, const double &DTime);
 
 /**
  * @brief Computes the tangent modulus that links the Piola-Kirchoff II stress \f$ \mathbf{S} \f$ to the Green-Lagrange stress \f$ \mathbf{E} \f$ from the tangent modulus that links the Kirchoff stress tensor \f$ \mathbf{\tau} \f$ and logarithmic strain \f$ \mathbf{e} \f$ integrated using the logarithmic spin

--- a/src/Continuum_mechanics/Functions/objective_rates.cpp
+++ b/src/Continuum_mechanics/Functions/objective_rates.cpp
@@ -501,14 +501,31 @@ mat Delta_log_strain_F(const mat &D, const mat &L, const double &DTime) {
     return 0.5*(D+(DF*D*inv(DF)))*DTime;
 }
 
-// Corate-dispatched log-strain increment (full doc in objective_rates.hpp): exact closed form for
-// XBM(2)/log_F(5), A^R:D for log_R(3), plain D for Jaumann/GN/Truesdell(0/1/4).
+// Corate spin dispatch (full doc in objective_rates.hpp): set DR + rate D + spin/L Omega for the
+// chosen objective rate. Single source of truth for the solver's control_type ladders.
+void corate_kinematics(const int &corate_type, mat &DR, mat &D, mat &Omega, const mat &F0, const mat &F1, const double &DTime) {
+    mat N_1 = zeros(3,3), N_2 = zeros(3,3);
+    switch (corate_type) {
+        case 0: Jaumann(DR, D, Omega, DTime, F0, F1); break;
+        case 1: Green_Naghdi(DR, D, Omega, DTime, F0, F1); break;
+        case 2: logarithmic(DR, D, Omega, DTime, F0, F1); break;
+        case 3: logarithmic_R(DR, N_1, N_2, D, Omega, DTime, F0, F1); break;   // DR = R-rotation
+        case 4: Truesdell(DR, D, Omega, DTime, F0, F1); break;                 // DR = DF, Omega = L
+        case 5: logarithmic_F(DR, N_1, N_2, D, Omega, DTime, F0, F1); break;   // DR = DF, Omega = L
+        default: break;
+    }
+}
+
+// Corate-dispatched log-strain increment (full doc in objective_rates.hpp): A^F:D rate for log_F(5),
+// closed form for XBM(2), A^R:D for log_R(3), plain D for Jaumann/GN/Truesdell(0/1/4).
 mat Delta_log_strain_corate(const mat &F0, const mat &F1, const mat &DR, const mat &D, const mat &Omega, const double &DTime, const int &corate_type) {
-    if (corate_type == 2 || corate_type == 5) {   // closed-form exact spatial log-strain difference -> etot = ln V1
+    if (corate_type == 5) {   // log_F: convected A^F:D rate (Omega carries the velocity gradient L)
+        return Delta_log_strain_F(v2t_strain(A_F(F1)*t2v_strain(D)), Omega, DTime);
+    }
+    if (corate_type == 2) {   // XBM: exact closed-form spatial log-strain difference -> etot = ln V1
         mat lnV0 = 0.5*logmat_sympd(L_Cauchy_Green(F0));
         mat lnV1 = 0.5*logmat_sympd(L_Cauchy_Green(F1));
-        if (corate_type == 5) return lnV1 - DR*lnV0*inv(DR);   // log_F: convected (inv DF) transport
-        return lnV1 - DR*lnV0*DR.t();                          // XBM:   orthogonal (DR^T) transport
+        return lnV1 - DR*lnV0*DR.t();                          // orthogonal (DR^T) transport
     }
     // corate 3 (log_R): A^R:D = the R-corotational (Green-Naghdi) rate of ln V, integrated in the
     // natural frame -> recovers ln V (~2e-4) and is frame-indifferent under rigid rotation. The

--- a/src/Continuum_mechanics/Functions/objective_rates.cpp
+++ b/src/Continuum_mechanics/Functions/objective_rates.cpp
@@ -385,8 +385,11 @@ mat A_R(const mat &F) {
     return AR;
 }
 
-// A^F: log_F-frame strain-concentration tensor (full doc in objective_rates.hpp).
-// t*coth(t) - 1/2 ln(b_i b_j) kernel; deliberately indefinite past lambda = sqrt(e).
+// A^F: log_F-frame (convected) strain-concentration tensor (full doc in objective_rates.hpp).
+// Kernel t*coth(t), t = 1/2 ln(b_i/b_j) -> diagonal = 1, so A^F:D recovers ln V (like A^R:D) in
+// the convected F-frame. The cosh(t) factor vs A_R's t/sinh(t) compensates the convected (inv DF)
+// transport. (An earlier "-1/2 ln(b_i b_j)" term made it deliberately indefinite past lambda=sqrt(e);
+// that corrupted the diagonal to 1-2 lnλ and was the bug -- A^F MUST integrate to ln V, as A^R does.)
 mat A_F(const mat &F) {
     mat B = L_Cauchy_Green(F);
     vec bi = zeros(3);
@@ -405,7 +408,7 @@ mat A_F(const mat &F) {
             } else {
                 tcoth = 1. + t*t/3. - t*t*t*t/45.;       // Taylor of t*coth(t)
             }
-            double c = tcoth - 0.5*log(bi(i)*bi(j));     // t*coth(t) - 1/2 ln(b_i b_j)
+            double c = tcoth;     // t*coth(t): F-frame strain-concentration kernel (diagonal -> 1, recovers ln V)
             AF = AF + c*linearop_eigsym(Bi.col(i),Bi.col(j));
         }
     }
@@ -507,8 +510,13 @@ mat Delta_log_strain_corate(const mat &F0, const mat &F1, const mat &DR, const m
         if (corate_type == 5) return lnV1 - DR*lnV0*inv(DR);   // log_F: convected (inv DF) transport
         return lnV1 - DR*lnV0*DR.t();                          // XBM:   orthogonal (DR^T) transport
     }
+    // corate 3 (log_R): A^R:D = the R-corotational (Green-Naghdi) rate of ln V, integrated in the
+    // natural frame -> recovers ln V (~2e-4) and is frame-indifferent under rigid rotation. The
+    // log_R spin is carried by sv_M->DR (logarithmic_R); the solver must NOT also apply the DR_N
+    // natural-basis rotation -- stacking both double-counts the log_R correction (undershoots ln V
+    // by ~11% under large open shear). A^R:D alone is the correct, self-consistent formulation.
     if (corate_type == 3) return Delta_log_strain(v2t_strain(A_R(F1)*t2v_strain(D)), Omega, DTime);  // log_R: A^R:D
-    return Delta_log_strain(D, Omega, DTime);                                                        // Jaumann/GN/Truesdell
+    return Delta_log_strain(D, Omega, DTime);   // Jaumann / GN / Truesdell
 }
 
 //This function computes the tangent modulus that links the Piola-Kirchoff II stress S to the Green-Lagrange stress E to the tangent modulus that links the Kirchoff elastic tensor and logarithmic strain, through the log rate and the and the transformation gradient F

--- a/src/Simulation/Solver/solver.cpp
+++ b/src/Simulation/Solver/solver.cpp
@@ -404,20 +404,11 @@ void solver(const string &umat_name, const vec &props, const unsigned int &nstat
                                         }
                                         mat N_1 = zeros(3,3);
                                         mat N_2 = zeros(3,3);
-                                        if(corate_type == 3) {
+                                        if(corate_type == 3) {  // log_R: A^R:D; spin carried by sv_M->DR. NO separate DR_N
+                                            // natural-basis rotation -- A^R:D already supplies the log_R correction, so a
+                                            // DR_N transport on top double-counts it (undershoots ln V by ~11%).
                                             logarithmic_R(sv_M->DR, N_1, N_2, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            mat I = eye(3,3);
-                                            mat DR_N_inv;
-                                            bool inv_success = inv(DR_N_inv, I-0.5*DTime*(N_1-N_2));
-                                            if (!inv_success) {
-                                                throw simcoon::exception_solver("Singular matrix in natural basis rotation update (corate_type=3).");
-                                            }
-                                            mat DR_N = DR_N_inv*(I+0.5*DTime*(N_1-N_2));
-
                                             sv_M->Detot = t2v_strain(Delta_log_strain_corate(sv_M->F0, sv_M->F1, sv_M->DR, D, Omega, DTime, corate_type));
-                                            sv_M->etot = rotate_strain(sv_M->etot, DR_N);
-                                            sv_M->sigma_start = rotate_stress(sv_M->sigma_start, DR_N);
-                                            sv_M->Detot = rotate_strain(sv_M->Detot, DR_N);
                                         }
                                         if(corate_type == 4) {
                                             Truesdell(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
@@ -425,15 +416,15 @@ void solver(const string &umat_name, const vec &props, const unsigned int &nstat
     //                                            log_modified2(sv_M->DR, N_1, N_2, D, Omega, DTime, sv_M->F0, sv_M->F1);
                                         }
                                         if(corate_type == 5) {
-                                            // log_F: De = A^F:D (convected/Oldroyd rate of ln V; see A_F + Delta_log_strain_corate
-                                            // in objective_rates.hpp). NLGEOM-only -- A^F indefinite past lambda=sqrt(e); DF applied inv NOT transpose.
+                                            // log_F: De = A^F:D -- the convected (Oldroyd) rate of ln V, passed as a genuine RATE of
+                                            // deformation. REQUIRED so inelastic UMATs integrate the constitutive law from De; an exact-
+                                            // kinematic ln V closed form (lnV1 - DF lnV0 inv(DF)) recovers ln V for hyperelastic but is
+                                            // NOT a rate and would silently break plasticity/SMA. Frame transported ONCE by set_start
+                                            // (sv_M->DR = DF, inv-branch) -- NO explicit DF rotation here (that double-transports). Departs
+                                            // from ln V approaching/past lambda=sqrt(e): the genuine naive-log_F / SVK convected pathology.
                                             mat Lvel;
                                             logarithmic_F(sv_M->DR, N_1, N_2, D, Lvel, DTime, sv_M->F0, sv_M->F1); // sv_M->DR = DF
-                                            mat DF = sv_M->DR;
-                                            sv_M->Detot       = t2v_strain(Delta_log_strain_F(v2t_strain(A_F(sv_M->F1)*t2v_strain(D)), Lvel, DTime)); // A^F:D = upper-convected (Oldroyd) rate of ln V, convected midpoint
-                                            sv_M->etot        = t2v_strain(DF * v2t_strain(sv_M->etot)        * inv(DF));  // DF correction: inv, NOT transpose
-                                            sv_M->sigma_start = t2v_stress(DF * v2t_stress(sv_M->sigma_start) * inv(DF));
-                                            sv_M->Detot       = t2v_strain(DF * v2t_strain(sv_M->Detot)       * inv(DF));
+                                            sv_M->Detot = t2v_strain(Delta_log_strain_F(v2t_strain(A_F(sv_M->F1)*t2v_strain(D)), Lvel, DTime)); // A^F:D
                                         }
                                         sv_M->DEtot = t2v_strain(Green_Lagrange(sv_M->F1)) - sv_M->Etot;
                                     }

--- a/src/Simulation/Solver/solver.cpp
+++ b/src/Simulation/Solver/solver.cpp
@@ -278,23 +278,7 @@ void solver(const string &umat_name, const vec &props, const unsigned int &nstat
                                         
                                         mat D = zeros(3,3);
                                         mat Omega = zeros(3,3);
-                                        if(corate_type == 0) {
-                                            Jaumann(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                        }
-                                        if(corate_type == 1) {
-                                            Green_Naghdi(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                        }
-                                        if(corate_type == 2) {
-                                            logarithmic(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                        }
-                                        if(corate_type == 3) {  // log_R: orthogonal frame
-                                            mat N_1 = zeros(3,3), N_2 = zeros(3,3);
-                                            logarithmic_R(sv_M->DR, N_1, N_2, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                        }
-                                        if(corate_type == 5) {  // naive log_F: convected frame, sv_M->DR = DF (Omega receives the velocity gradient L)
-                                            mat N_1 = zeros(3,3), N_2 = zeros(3,3);
-                                            logarithmic_F(sv_M->DR, N_1, N_2, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                        }
+                                        corate_kinematics(corate_type, sv_M->DR, D, Omega, sv_M->F0, sv_M->F1, DTime);
 
                                         sv_M->Detot = t2v_strain(Delta_log_strain_corate(sv_M->F0, sv_M->F1, sv_M->DR, D, Omega, DTime, corate_type));
                                         //mat e_tot_log = t2v_strain(0.5*logmat_sympd(L_Cauchy_Green(sv_M->F1)));
@@ -318,23 +302,7 @@ void solver(const string &umat_name, const vec &props, const unsigned int &nstat
 
                                         mat D = zeros(3,3);
                                         mat Omega = zeros(3,3);
-                                        if(corate_type == 0) {
-                                            Jaumann(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                        }
-                                        if(corate_type == 1) {
-                                            Green_Naghdi(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                        }
-                                        if(corate_type == 2) {
-                                            logarithmic(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                        }
-                                        if(corate_type == 3) {  // log_R: orthogonal frame
-                                            mat N_1 = zeros(3,3), N_2 = zeros(3,3);
-                                            logarithmic_R(sv_M->DR, N_1, N_2, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                        }
-                                        if(corate_type == 5) {  // naive log_F: convected frame, sv_M->DR = DF (Omega receives the velocity gradient L)
-                                            mat N_1 = zeros(3,3), N_2 = zeros(3,3);
-                                            logarithmic_F(sv_M->DR, N_1, N_2, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                        }
+                                        corate_kinematics(corate_type, sv_M->DR, D, Omega, sv_M->F0, sv_M->F1, DTime);
 
                                         sv_M->DEtot = t2v_strain(Green_Lagrange(sv_M->F1)) - sv_M->Etot;
                                         
@@ -363,23 +331,7 @@ void solver(const string &umat_name, const vec &props, const unsigned int &nstat
                                                                                 
                                         mat D = zeros(3,3);
                                         mat Omega = zeros(3,3);
-                                        if(corate_type == 0) {
-                                            Jaumann(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                        }
-                                        if(corate_type == 1) {
-                                            Green_Naghdi(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                        }
-                                        if(corate_type == 2) {
-                                            logarithmic(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                        }
-                                        if(corate_type == 3) {  // log_R: orthogonal frame
-                                            mat N_1 = zeros(3,3), N_2 = zeros(3,3);
-                                            logarithmic_R(sv_M->DR, N_1, N_2, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                        }
-                                        if(corate_type == 5) {  // naive log_F: convected frame, sv_M->DR = DF (Omega receives the velocity gradient L)
-                                            mat N_1 = zeros(3,3), N_2 = zeros(3,3);
-                                            logarithmic_F(sv_M->DR, N_1, N_2, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                        }
+                                        corate_kinematics(corate_type, sv_M->DR, D, Omega, sv_M->F0, sv_M->F1, DTime);
 
                                         sv_M->Detot = t2v_strain(Delta_log_strain_corate(sv_M->F0, sv_M->F1, sv_M->DR, D, Omega, DTime, corate_type));
                                     }                                    
@@ -390,42 +342,8 @@ void solver(const string &umat_name, const vec &props, const unsigned int &nstat
                                     
                                         mat D = zeros(3,3);
                                         mat Omega = zeros(3,3);
-                                        if(corate_type == 0) {
-                                            Jaumann(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            sv_M->Detot = t2v_strain(Delta_log_strain_corate(sv_M->F0, sv_M->F1, sv_M->DR, D, Omega, DTime, corate_type));
-                                        }
-                                        if(corate_type == 1) {
-                                            Green_Naghdi(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            sv_M->Detot = t2v_strain(Delta_log_strain_corate(sv_M->F0, sv_M->F1, sv_M->DR, D, Omega, DTime, corate_type));
-                                        }
-                                        if(corate_type == 2) {
-                                            logarithmic(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            sv_M->Detot = t2v_strain(Delta_log_strain_corate(sv_M->F0, sv_M->F1, sv_M->DR, D, Omega, DTime, corate_type));
-                                        }
-                                        mat N_1 = zeros(3,3);
-                                        mat N_2 = zeros(3,3);
-                                        if(corate_type == 3) {  // log_R: A^R:D; spin carried by sv_M->DR. NO separate DR_N
-                                            // natural-basis rotation -- A^R:D already supplies the log_R correction, so a
-                                            // DR_N transport on top double-counts it (undershoots ln V by ~11%).
-                                            logarithmic_R(sv_M->DR, N_1, N_2, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            sv_M->Detot = t2v_strain(Delta_log_strain_corate(sv_M->F0, sv_M->F1, sv_M->DR, D, Omega, DTime, corate_type));
-                                        }
-                                        if(corate_type == 4) {
-                                            Truesdell(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            sv_M->Detot = t2v_strain(Delta_log_strain_corate(sv_M->F0, sv_M->F1, sv_M->DR, D, Omega, DTime, corate_type));
-    //                                            log_modified2(sv_M->DR, N_1, N_2, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                        }
-                                        if(corate_type == 5) {
-                                            // log_F: De = A^F:D -- the convected (Oldroyd) rate of ln V, passed as a genuine RATE of
-                                            // deformation. REQUIRED so inelastic UMATs integrate the constitutive law from De; an exact-
-                                            // kinematic ln V closed form (lnV1 - DF lnV0 inv(DF)) recovers ln V for hyperelastic but is
-                                            // NOT a rate and would silently break plasticity/SMA. Frame transported ONCE by set_start
-                                            // (sv_M->DR = DF, inv-branch) -- NO explicit DF rotation here (that double-transports). Departs
-                                            // from ln V approaching/past lambda=sqrt(e): the genuine naive-log_F / SVK convected pathology.
-                                            mat Lvel;
-                                            logarithmic_F(sv_M->DR, N_1, N_2, D, Lvel, DTime, sv_M->F0, sv_M->F1); // sv_M->DR = DF
-                                            sv_M->Detot = t2v_strain(Delta_log_strain_F(v2t_strain(A_F(sv_M->F1)*t2v_strain(D)), Lvel, DTime)); // A^F:D
-                                        }
+                                        corate_kinematics(corate_type, sv_M->DR, D, Omega, sv_M->F0, sv_M->F1, DTime);
+                                        sv_M->Detot = t2v_strain(Delta_log_strain_corate(sv_M->F0, sv_M->F1, sv_M->DR, D, Omega, DTime, corate_type));
                                         sv_M->DEtot = t2v_strain(Green_Lagrange(sv_M->F1)) - sv_M->Etot;
                                     }
                                     rve.to_start();
@@ -569,26 +487,7 @@ void solver(const string &umat_name, const vec &props, const unsigned int &nstat
                                     
                                             mat D = zeros(3,3);
                                             mat Omega = zeros(3,3);
-                                            if(corate_type == 0) {
-                                                Jaumann(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }
-                                            if(corate_type == 1) {
-                                                Green_Naghdi(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }
-                                            if(corate_type == 2) {
-                                                logarithmic(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }
-                                            if(corate_type == 3) {  // log_R: orthogonal frame
-                                                mat N_1 = zeros(3,3), N_2 = zeros(3,3);
-                                                logarithmic_R(sv_M->DR, N_1, N_2, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }
-                                            if(corate_type == 5) {  // naive log_F: convected frame, sv_M->DR = DF (Omega receives the velocity gradient L)
-                                                mat N_1 = zeros(3,3), N_2 = zeros(3,3);
-                                                logarithmic_F(sv_M->DR, N_1, N_2, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }
-                                            if(corate_type == 4) {
-                                                Truesdell(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }                                            
+                                            corate_kinematics(corate_type, sv_M->DR, D, Omega, sv_M->F0, sv_M->F1, DTime);
                                             sv_M->Detot = t2v_strain(Delta_log_strain_corate(sv_M->F0, sv_M->F1, sv_M->DR, D, Omega, DTime, corate_type));
                                         }
                                         else if (blocks[i].control_type == 3) {
@@ -611,23 +510,7 @@ void solver(const string &umat_name, const vec &props, const unsigned int &nstat
 
                                             mat D = zeros(3,3);
                                             mat Omega = zeros(3,3);
-                                            if(corate_type == 0) {
-                                                Jaumann(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }
-                                            if(corate_type == 1) {
-                                                Green_Naghdi(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }
-                                            if(corate_type == 2) {
-                                                logarithmic(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }
-                                            if(corate_type == 3) {  // log_R: orthogonal frame
-                                                mat N_1 = zeros(3,3), N_2 = zeros(3,3);
-                                                logarithmic_R(sv_M->DR, N_1, N_2, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }
-                                            if(corate_type == 5) {  // naive log_F: convected frame, sv_M->DR = DF (Omega receives the velocity gradient L)
-                                                mat N_1 = zeros(3,3), N_2 = zeros(3,3);
-                                                logarithmic_F(sv_M->DR, N_1, N_2, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }
+                                            corate_kinematics(corate_type, sv_M->DR, D, Omega, sv_M->F0, sv_M->F1, DTime);
                                             if (DTime > simcoon::iota)
                                                 D = sv_M->Detot/DTime;
                                             else
@@ -650,26 +533,7 @@ void solver(const string &umat_name, const vec &props, const unsigned int &nstat
                                             sv_M->DEtot = t2v_strain(Green_Lagrange(sv_M->F1)) - sv_M->Etot;;
                                             mat D = zeros(3,3);
                                             mat Omega = zeros(3,3);
-                                            if(corate_type == 0) {
-                                                Jaumann(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }
-                                            if(corate_type == 1) {
-                                                Green_Naghdi(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }
-                                            if(corate_type == 2) {
-                                                logarithmic(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }
-                                            if(corate_type == 3) {  // log_R: orthogonal frame
-                                                mat N_1 = zeros(3,3), N_2 = zeros(3,3);
-                                                logarithmic_R(sv_M->DR, N_1, N_2, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }
-                                            if(corate_type == 5) {  // naive log_F: convected frame, sv_M->DR = DF (Omega receives the velocity gradient L)
-                                                mat N_1 = zeros(3,3), N_2 = zeros(3,3);
-                                                logarithmic_F(sv_M->DR, N_1, N_2, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }
-                                            if(corate_type == 4) {
-                                                Truesdell(sv_M->DR, D, Omega, DTime, sv_M->F0, sv_M->F1);
-                                            }    
+                                            corate_kinematics(corate_type, sv_M->DR, D, Omega, sv_M->F0, sv_M->F1, DTime);
                                             sv_M->Detot = t2v_strain(Delta_log_strain_corate(sv_M->F0, sv_M->F1, sv_M->DR, D, Omega, DTime, corate_type));
                                         }      
                                         rve.to_start();


### PR DESCRIPTION
This pull request introduces a new example for parameter identification using the deployable `MOORI` UMAT and Simcoon's identification API, adds supporting experimental data files, and makes important corrections and improvements to the implementation and documentation of objective rates in the continuum mechanics code. The most significant changes are grouped below.

---

**New example and documentation:**

* Added `examples/hyperelasticity/hyperelastic_umat_identification.py`, which demonstrates Mooney-Rivlin parameter identification using the production `MOORI` UMAT, Simcoon's solver, and the identification API. This example mirrors the analytical version but exercises the deployable UMAT and library-native cost function.
* Added a `README.rst` to `examples/identification` explaining the parameter identification workflow and cross-linking the two hyperelastic identification examples.
* Updated the docstring in `examples/analysis/hyperelastic_parameter_identification.py` to reference the new UMAT-based example and clarify the relationship between the two approaches.

**Experimental data:**

* Added three experimental load-path files (`path_UT_id.txt`, `path_PS_id.txt`, `path_ET_id.txt`) under `examples/hyperelasticity/data/`, which are used by the new UMAT identification example. [[1]](diffhunk://#diff-fe1fa5ff91633eb48a105bd0f108d94f35fd46a63af89a4a8d981686d533e4d6R1-R33) [[2]](diffhunk://#diff-af02536c16a32de6ec4e0f5867f17adc380477f29618ee15e50153ee70870377R1-R33) [[3]](diffhunk://#diff-1feea35ac9b647c754a825123ec700cbe46232e9f18764cff1d227161fe43bc5R1-R33)

**Objective rate implementation and documentation:**

* Corrected the mathematical formulation and documentation of the log_F (convected) objective rate in both the header (`objective_rates.hpp`) and implementation (`objective_rates.cpp`). The indefinite term in the strain-concentration tensor was removed, ensuring that `A^F:D` now correctly integrates to `ln V`, matching the behavior of `A^R:D` for log_R. [[1]](diffhunk://#diff-2008033d0ab27f639467d58634b361756e3986a4a7f633b054c0093782ffc3f5L351-R355) [[2]](diffhunk://#diff-a708cc0a28a9911826a6ce55e3bfa3968d4c94b50ed6ce7677466123a9fa86daL388-R392) [[3]](diffhunk://#diff-a708cc0a28a9911826a6ce55e3bfa3968d4c94b50ed6ce7677466123a9fa86daL408-R411)
* Added and documented a new `corate_kinematics` function to centralize the dispatch of frame increments and rate-of-deformation tensors for all objective rates, ensuring consistent behavior across all control types. Updated `Delta_log_strain_corate` to use the corrected log_F implementation. [[1]](diffhunk://#diff-2008033d0ab27f639467d58634b361756e3986a4a7f633b054c0093782ffc3f5R364-R373) [[2]](diffhunk://#diff-a708cc0a28a9911826a6ce55e3bfa3968d4c94b50ed6ce7677466123a9fa86daL501-R534)