### PR TITLE
Rename VoigtType to Tensor2Type and update API

### DIFF
--- a/examples/mechanical/MODUL.py
+++ b/examples/mechanical/MODUL.py
@@ -33,9 +33,15 @@ plt.rcParams["figure.figsize"] = (14, 6)
 # ----------------------------------
 # Isotropic elasticity + von Mises yield + Voce isotropic hardening.
 # Parameters: E=210 GPa, nu=0.3, sigma_Y=300 MPa, Q=200 MPa, b=10.
+#
+# The elastic constants C1/C2 are ordinal slots whose meaning is fixed by the
+# ``convention`` argument — here ``"Enu"`` (C1 = E, C2 = nu). Other
+# parameterizations ("Kmu", "lambdamu", ...) are accepted as well.
 
 mat = ModularMaterial(
-    elasticity=IsotropicElasticity(C1=210000.0, C2=0.3, alpha=1.2e-5),
+    elasticity=IsotropicElasticity(
+        C1=210000.0, C2=0.3, alpha=1.2e-5, convention="Enu"
+    ),
     mechanisms=[
         Plasticity(
             sigma_Y=300.0,

--- a/include/simcoon/Continuum_mechanics/Functions/tensor.hpp
+++ b/include/simcoon/Continuum_mechanics/Functions/tensor.hpp
@@ -36,12 +36,17 @@ class tensor4;
  * - generic: same storage as stress (symmetric tensor, no physical convention)
  * - none:    non-symmetric tensor (e.g. F), .voigt() throws
  */
-enum class VoigtType {
+enum class Tensor2Type {
     stress,
     strain,
     generic,
     none
 };
+
+/// Deprecated pre-2.0 alias — the tag was named after the Voigt encoding
+/// rather than the tensor rank (asymmetric with Tensor4Type). Kept for
+/// external users (e.g. fedoo); prefer Tensor2Type.
+using VoigtType = Tensor2Type;
 
 /**
  * @brief Type tag for 4th-order tensors: selects the engineering<->Mandel congruence,
@@ -137,35 +142,35 @@ enum class CoRate {
 class tensor2 {
 private:
     arma::mat::fixed<3,3> _mat;
-    VoigtType _vtype;
+    Tensor2Type _vtype;
 
 public:
-    /// Zero tensor, VoigtType::stress.
+    /// Zero tensor, Tensor2Type::stress.
     tensor2();
     /// Zero tensor with the given type tag.
-    explicit tensor2(VoigtType vtype);
+    explicit tensor2(Tensor2Type vtype);
     /// Wrap a 3x3 matrix (true components, no Voigt factor) with a type tag.
-    tensor2(const arma::mat::fixed<3,3> &m, VoigtType vtype);
+    tensor2(const arma::mat::fixed<3,3> &m, Tensor2Type vtype);
     /// Same, from a dynamic arma::mat (must be 3x3).
-    tensor2(const arma::mat &m, VoigtType vtype);
+    tensor2(const arma::mat &m, Tensor2Type vtype);
 
     /// Build from an engineering Voigt 6-vector \f$[t_{11},t_{22},t_{33},t_{12},t_{13},t_{23}]\f$;
     /// strain halves the shear entries (engineering \f$\gamma_{ij}=2\varepsilon_{ij}\f$), stress uses them as-is.
-    static tensor2 from_voigt(const arma::vec::fixed<6> &v, VoigtType vtype);
+    static tensor2 from_voigt(const arma::vec::fixed<6> &v, Tensor2Type vtype);
     /// Same, from a dynamic arma::vec (must have 6 elements).
-    static tensor2 from_voigt(const arma::vec &v, VoigtType vtype);
+    static tensor2 from_voigt(const arma::vec &v, Tensor2Type vtype);
     /// Same, with a string tag ("stress"/"strain"/"generic") — parses per call; prefer the enum overload in loops.
     static tensor2 from_voigt(const arma::vec &v, const std::string &type_str);
 
     /// Build from a Kelvin-Mandel vector (shear scaled by \f$\sqrt2\f$, identical for stress/strain).
-    static tensor2 from_mandel(const arma::vec::fixed<6> &v, VoigtType vtype);
+    static tensor2 from_mandel(const arma::vec::fixed<6> &v, Tensor2Type vtype);
 
     /// Zero tensor factory.
-    static tensor2 zeros(VoigtType vtype = VoigtType::stress);
+    static tensor2 zeros(Tensor2Type vtype = Tensor2Type::stress);
     /// Zero tensor factory (string tag).
     static tensor2 zeros(const std::string &type_str);
     /// Identity tensor \f$\mathbf{I}\f$ factory.
-    static tensor2 identity(VoigtType vtype = VoigtType::stress);
+    static tensor2 identity(Tensor2Type vtype = Tensor2Type::stress);
     /// Identity tensor factory (string tag).
     static tensor2 identity(const std::string &type_str);
 
@@ -190,12 +195,12 @@ public:
     void set_voigt(const arma::vec &v);
 
     /// The Voigt type tag.
-    VoigtType vtype() const { return _vtype; }
+    Tensor2Type vtype() const { return _vtype; }
 
     /**
      * @brief Compute Voigt vector on the fly (6 lookups + factor-2 on shear for strain).
      * @return vec::fixed<6> by value
-     * @throws std::runtime_error if VoigtType::none
+     * @throws std::runtime_error if Tensor2Type::none
      */
     arma::vec::fixed<6> voigt() const;
 
@@ -223,7 +228,7 @@ public:
     /// Rotate: \f$\mathbf{Q}\,\mathbf{X}\,\mathbf{Q}^T\f$ (passive uses \f$\mathbf{Q}^T\f$).
     tensor2 rotate(const Rotation &R, bool active = true) const;
 
-    /// Push-forward to the spatial configuration; kernel dispatches on VoigtType
+    /// Push-forward to the spatial configuration; kernel dispatches on Tensor2Type
     /// (stress: \f$\mathbf{F}\mathbf{X}\mathbf{F}^T\f$, strain: \f$\mathbf{F}^{-T}\mathbf{X}\mathbf{F}^{-1}\f$).
     /// metric=true (default) includes the \f$J=\det\mathbf{F}\f$ Piola factor; metric=false = pure transport.
     tensor2 push_forward(const arma::mat::fixed<3,3> &F, bool metric = true) const;
@@ -305,7 +310,7 @@ double trace(const tensor2 &t);
  *
  * @param sigma stress tensor
  * @param alpha pressure-sensitivity (friction) coefficient; 0 → von Mises
- * @return \f$\partial\Phi/\partial\sigma\f$, VoigtType::strain
+ * @return \f$\partial\Phi/\partial\sigma\f$, Tensor2Type::strain
  * @see flow() for the plastic-potential normal (non-associative flow)
  */
 tensor2 flow_normal(const tensor2 &sigma, double alpha = 0.0);
@@ -325,7 +330,7 @@ tensor2 flow_normal(const tensor2 &sigma, double alpha = 0.0);
  *
  * @param sigma stress tensor
  * @param beta  dilatancy coefficient (\f$\le\alpha\f$ for the 2nd law)
- * @return \f$\partial H/\partial\sigma\f$, VoigtType::strain
+ * @return \f$\partial H/\partial\sigma\f$, Tensor2Type::strain
  * @see flow_normal() for the yield-surface normal
  */
 tensor2 flow(const tensor2 &sigma, double beta = 0.0);
@@ -439,7 +444,7 @@ public:
      * @brief Contract with a tensor2 (double contraction), e.g. sigma = L : eps.
      *        Internally a plain Mandel matrix-vector product.
      *
-     * Output VoigtType is inferred from Tensor4Type:
+     * Output Tensor2Type is inferred from Tensor4Type:
      * - stiffness (sigma = L : epsilon) -> stress
      * - compliance (epsilon = M : sigma) -> strain
      * - strain_concentration (epsilon = A : epsilon) -> strain
@@ -555,28 +560,28 @@ tensor4 auto_sym_dyadic(const tensor2 &a);
 // rot/F with n_slices==1 are broadcast to all N points.
 
 /// Batch rotate N tensor2 objects. voigt:(6,N), rot:(3,3,N_r).
-arma::mat batch_rotate(const arma::mat &voigt, VoigtType vtype,
+arma::mat batch_rotate(const arma::mat &voigt, Tensor2Type vtype,
                        const arma::cube &rot_matrices, bool active = true);
 
 /// Batch push-forward N tensor2. voigt:(6,N), F:(3,3,N_f).
-arma::mat batch_push_forward(const arma::mat &voigt, VoigtType vtype,
+arma::mat batch_push_forward(const arma::mat &voigt, Tensor2Type vtype,
                              const arma::cube &F, bool metric = true);
 
 /// Batch pull-back N tensor2. voigt:(6,N), F:(3,3,N_f).
-arma::mat batch_pull_back(const arma::mat &voigt, VoigtType vtype,
+arma::mat batch_pull_back(const arma::mat &voigt, Tensor2Type vtype,
                           const arma::cube &F, bool metric = true);
 
 /// Batch von Mises for N tensor2. voigt:(6,N) → (N).
-arma::vec batch_mises(const arma::mat &voigt, VoigtType vtype);
+arma::vec batch_mises(const arma::mat &voigt, Tensor2Type vtype);
 
 /// Batch trace for N tensor2. voigt:(6,N) → (N).
-arma::vec batch_trace(const arma::mat &voigt, VoigtType vtype);
+arma::vec batch_trace(const arma::mat &voigt, Tensor2Type vtype);
 
-/// Infers the output VoigtType of a tensor4 @ tensor2 contraction from the tensor4 type.
-VoigtType infer_contraction_vtype(Tensor4Type t4type);
+/// Infers the output Tensor2Type of a tensor4 @ tensor2 contraction from the tensor4 type.
+Tensor2Type infer_contraction_vtype(Tensor4Type t4type);
 /// Batch contract tensor4 @ tensor2. t4:(6,6,N4), t2:(6,N2) → (6,N); pair with infer_contraction_vtype for the output type.
 arma::mat batch_contract(const arma::cube &t4, Tensor4Type t4type,
-                         const arma::mat &t2, VoigtType t2_vtype);
+                         const arma::mat &t2, Tensor2Type t2_vtype);
 
 /// Batch rotate N tensor4 (overload of the tensor2 version). t4:(6,6,N), rot:(3,3,N_r).
 arma::cube batch_rotate(const arma::cube &t4, Tensor4Type t4type,

--- a/include/simcoon/Continuum_mechanics/Umat/Modular/damage_mechanism.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/damage_mechanism.hpp
@@ -97,8 +97,8 @@ private:
                                         ///< compute_driving_force, dPhi_dsigma,
                                         ///< kappa, tangent_contribution.
     mutable bool M_cached_valid_;       ///< Whether the cached compliances are valid
-    mutable std::vector<tensor2> dPhi_dsigma_cache_{tensor2(VoigtType::strain)};
-    mutable std::vector<tensor2> kappa_cache_{tensor2(VoigtType::strain)};
+    mutable std::vector<tensor2> dPhi_dsigma_cache_{tensor2(Tensor2Type::strain)};
+    mutable std::vector<tensor2> kappa_cache_{tensor2(Tensor2Type::strain)};
 
 public:
     /**

--- a/include/simcoon/Continuum_mechanics/Umat/Modular/elasticity_module.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/elasticity_module.hpp
@@ -277,7 +277,7 @@ public:
      * @brief Stiffness as a typed Tensor4 (cached — built once per configure).
      *
      * Use `.contract(strain_tensor)` to obtain the elastic stress tensor2 with
-     * the correct VoigtType automatically inferred. Returned by const-ref so
+     * the correct Tensor2Type automatically inferred. Returned by const-ref so
      * hot loops can contract without paying the eng→Mandel congruence per call.
      */
     [[nodiscard]] const tensor4& L_tensor() const noexcept { return L_t_; }

--- a/include/simcoon/Continuum_mechanics/Umat/Modular/hardening.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/hardening.hpp
@@ -271,7 +271,7 @@ public:
     [[nodiscard]] tensor2 total_backstress(const InternalVariableCollection& ivc) const {
         std::vector<tensor2> X_i;
         compute_backstresses(ivc, X_i);
-        tensor2 X_t = tensor2::zeros(VoigtType::stress);
+        tensor2 X_t = tensor2::zeros(Tensor2Type::stress);
         for (const auto& x : X_i) {
             X_t += x;
         }

--- a/include/simcoon/Continuum_mechanics/Umat/Modular/internal_variable.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/internal_variable.hpp
@@ -69,10 +69,10 @@ private:
     arma::mat mat_start_;        ///< Matrix value at start of increment
 
     bool is_objective_;          ///< Whether the quantity is objective (frame-indifferent)
-    VoigtType vtype_;            ///< Authoritative Voigt convention for this variable
+    Tensor2Type vtype_;            ///< Authoritative Voigt convention for this variable
                                  ///< (VECTOR_6): strain, stress, or generic. Drives
                                  ///< rotation dispatch (tensor2.rotate) and default
-                                 ///< VoigtType for as_tensor2() views. Ignored for
+                                 ///< Tensor2Type for as_tensor2() views. Ignored for
                                  ///< scalars and 6x6 matrices.
     Tensor4Type t4type_;         ///< Authoritative convention for MATRIX_6x6 variables
                                  ///< (stiffness, compliance, ...). Drives the rotation
@@ -97,15 +97,15 @@ public:
      * @param objective  Whether the quantity is objective (default: true; see
      *        is_objective() — pass false for velocity/rate-like variables)
      * @param vtype  Voigt convention for this variable:
-     *        VoigtType::strain (default) for strain-like variables (EP, EV, α, ...),
-     *        VoigtType::stress for stress-like variables (stored generalised forces),
-     *        VoigtType::generic for plain 6-component vectors without Voigt semantics.
+     *        Tensor2Type::strain (default) for strain-like variables (EP, EV, α, ...),
+     *        Tensor2Type::stress for stress-like variables (stored generalised forces),
+     *        Tensor2Type::generic for plain 6-component vectors without Voigt semantics.
      *        Controls the rotation kernel (strain-rotation has factor-2 on shear)
      *        and is returned by default from as_tensor2().
      */
     InternalVariable(const std::string& name, const arma::vec& init,
                       bool objective = true,
-                      VoigtType vtype = VoigtType::strain);
+                      Tensor2Type vtype = Tensor2Type::strain);
 
     /**
      * @brief Construct a matrix internal variable (6x6)
@@ -164,9 +164,9 @@ public:
      * @brief The Voigt convention of this variable.
      *
      * For VECTOR_6 variables, this tag drives the objectivity rotation kernel
-     * and the default VoigtType returned by as_tensor2().
+     * and the default Tensor2Type returned by as_tensor2().
      */
-    [[nodiscard]] VoigtType vtype() const noexcept { return vtype_; }
+    [[nodiscard]] Tensor2Type vtype() const noexcept { return vtype_; }
 
     /**
      * @brief The Tensor4 convention of this variable (MATRIX_6x6 only).
@@ -194,7 +194,7 @@ public:
      *
      * "raw" is deliberate: this is the escape hatch past set_tensor2()'s
      * convention re-expression — the components are engineering Voigt in this
-     * variable's own VoigtType, and the CALLER owns keeping them consistent
+     * variable's own Tensor2Type, and the CALLER owns keeping them consistent
      * (safe for same-convention linear combinations; use set_tensor2()
      * whenever the source is a typed tensor). To reconstruct the tensorial
      * quantity, do NOT re-tag raw copies — use as_tensor2()/as_tensor2_start(),
@@ -206,7 +206,7 @@ public:
     /**
      * @brief Access the raw Voigt components (const)
      * @return Const reference to the 6-component vector (this variable's
-     *         VoigtType convention)
+     *         Tensor2Type convention)
      * @throws std::runtime_error if type is not VECTOR_6
      */
     const arma::vec& raw_voigt() const;
@@ -275,7 +275,7 @@ public:
      * @param DR Rotation increment matrix (3x3)
      *
      * Scalars are left unchanged. VECTOR_6 internals rotate through tensor2
-     * with the variable's VoigtType (strain-rotation carries the factor-2 on
+     * with the variable's Tensor2Type (strain-rotation carries the factor-2 on
      * shear); MATRIX_6x6 internals rotate through tensor4 with the variable's
      * Tensor4Type, so the correct congruence is applied for stiffness- AND
      * compliance-like storage. No-op when is_objective() is false: a
@@ -295,32 +295,32 @@ public:
     /**
      * @brief View the stored vector as a typed tensor2.
      *
-     * The caller selects the VoigtType matching the physical quantity:
-     * - VoigtType::strain  for plastic strain, viscous strain, strain-form
+     * The caller selects the Tensor2Type matching the physical quantity:
+     * - Tensor2Type::strain  for plastic strain, viscous strain, strain-form
      *   backstress — assumes the factor-2 shear convention used by rotate()
      *   and pack().
-     * - VoigtType::stress  for stress-conjugate variables stored without the
+     * - Tensor2Type::stress  for stress-conjugate variables stored without the
      *   factor-2.
-     * - VoigtType::generic when no specific physical convention applies.
+     * - Tensor2Type::generic when no specific physical convention applies.
      *
      * @throws std::runtime_error if type() != VECTOR_6
      */
     /// When @p vtype_override is left default (none), the variable's own
-    /// stored VoigtType is used — callers never need to pass it explicitly
+    /// stored Tensor2Type is used — callers never need to pass it explicitly
     /// unless they want to reinterpret the raw Voigt components under a
     /// different convention (rare).
     [[nodiscard]] tensor2 as_tensor2() const { return as_tensor2(vtype_); }
-    [[nodiscard]] tensor2 as_tensor2(VoigtType vtype) const;
+    [[nodiscard]] tensor2 as_tensor2(Tensor2Type vtype) const;
 
     /// Typed view of the START value (state at the beginning of the
     /// increment) — the tensorial counterpart of raw_voigt_start(), so
     /// backward-Euler closed forms can be written fully typed.
     /// @throws std::runtime_error if type() != VECTOR_6
     [[nodiscard]] tensor2 as_tensor2_start() const { return as_tensor2_start(vtype_); }
-    [[nodiscard]] tensor2 as_tensor2_start(VoigtType vtype) const;
+    [[nodiscard]] tensor2 as_tensor2_start(Tensor2Type vtype) const;
 
-    [[nodiscard]] tensor2 as_strain() const { return as_tensor2(VoigtType::strain); }
-    [[nodiscard]] tensor2 as_stress() const { return as_tensor2(VoigtType::stress); }
+    [[nodiscard]] tensor2 as_strain() const { return as_tensor2(Tensor2Type::strain); }
+    [[nodiscard]] tensor2 as_stress() const { return as_tensor2(Tensor2Type::stress); }
 
     /// Default view: the variable's own stored Tensor4Type is used (see
     /// as_tensor2() for the same pattern on vectors).

--- a/include/simcoon/Continuum_mechanics/Umat/Modular/internal_variable_collection.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/internal_variable_collection.hpp
@@ -79,7 +79,7 @@ public:
     InternalVariable& add_vec(const std::string& name,
                                const arma::vec& init = arma::zeros(6),
                                bool objective = true,
-                               VoigtType vtype = VoigtType::strain);
+                               Tensor2Type vtype = Tensor2Type::strain);
 
     /**
      * @brief Add a 6x6 matrix internal variable

--- a/include/simcoon/Continuum_mechanics/Umat/Modular/plasticity_mechanism.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/plasticity_mechanism.hpp
@@ -68,8 +68,8 @@ private:
     // produced once per iteration in dPhi_dsigma()/kappa().
     mutable arma::vec flow_dir_;                ///< ∂Φ/∂σ (associated flow direction)
     mutable arma::vec kappa_;                   ///< L_ref · flow_dir_
-    mutable std::vector<tensor2> dPhi_dsigma_cache_{tensor2(VoigtType::strain)};
-    mutable std::vector<tensor2> kappa_cache_{tensor2(VoigtType::stress)};
+    mutable std::vector<tensor2> dPhi_dsigma_cache_{tensor2(Tensor2Type::strain)};
+    mutable std::vector<tensor2> kappa_cache_{tensor2(Tensor2Type::stress)};
     mutable std::vector<tensor4> hessian_cache_{tensor4(Tensor4Type::compliance)};
     mutable std::vector<tensor2> X_branches_;   ///< Per-branch backstresses, built
                                                 ///< ONCE per FB iteration in

--- a/include/simcoon/Continuum_mechanics/Umat/Modular/strain_mechanism.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/strain_mechanism.hpp
@@ -200,7 +200,7 @@ public:
      * (arma::dot of .voigt()), the work-conjugate pairing of a strain-typed
      * dPhi with a stress-typed kappa.
      *
-     * Typing: dPhi/dsigma is strain-typed (VoigtType::strain — the dEq_stress
+     * Typing: dPhi/dsigma is strain-typed (Tensor2Type::strain — the dEq_stress
      * convention, shear slots carry the doubled gamma components).
      *
      * Returned by const-ref into mechanism-internal storage populated during
@@ -227,7 +227,7 @@ public:
      * Length must equal num_constraints(). Same const-ref lifetime contract
      * as dPhi_dsigma — reference is valid until the next compute_constraints.
      *
-     * Typing: stress-typed (VoigtType::stress) for plasticity/viscoelasticity
+     * Typing: stress-typed (Tensor2Type::stress) for plasticity/viscoelasticity
      * (kappa = L·Lambda). DamageMechanism returns a strain-typed kappa
      * (kappa = ∂M/∂D · σ, an M·σ product) — see its override for why the
      * orchestrator's engineering-Voigt dot is kept for that pairing too.

--- a/python-setup/simcoon/tensor.py
+++ b/python-setup/simcoon/tensor.py
@@ -46,7 +46,7 @@ from simcoon._core import (
     _auto_dyadic,
     _sym_dyadic,
     _auto_sym_dyadic,
-    VoigtType as _VoigtType,
+    Tensor2Type as _Tensor2Type,
     Tensor4Type as _T4Type,
 )
 
@@ -66,10 +66,10 @@ from simcoon._core import (
 # ======================================================================
 
 _VTYPE_MAP = {
-    "stress": _VoigtType.stress,
-    "strain": _VoigtType.strain,
-    "generic": _VoigtType.generic,
-    "none": _VoigtType.none,
+    "stress": _Tensor2Type.stress,
+    "strain": _Tensor2Type.strain,
+    "generic": _Tensor2Type.generic,
+    "none": _Tensor2Type.none,
 }
 _VTYPE_RMAP = {v: k for k, v in _VTYPE_MAP.items()}
 

--- a/simcoon-python-builder/src/python_wrappers/Libraries/Continuum_mechanics/tensor.cpp
+++ b/simcoon-python-builder/src/python_wrappers/Libraries/Continuum_mechanics/tensor.cpp
@@ -52,14 +52,17 @@ namespace {
 
 void register_tensor(py::module_& m) {
 
-    // VoigtType enum
-    py::enum_<simcoon::VoigtType>(m, "VoigtType",
+    // Tensor2Type enum
+    py::enum_<simcoon::Tensor2Type>(m, "Tensor2Type",
         "Type tag for 2nd-order tensors, determines Voigt conversion factors and rotation rules.")
-        .value("stress", simcoon::VoigtType::stress, "Voigt = [s11, s22, s33, s12, s13, s23]")
-        .value("strain", simcoon::VoigtType::strain, "Voigt = [e11, e22, e33, 2*e12, 2*e13, 2*e23]")
-        .value("generic", simcoon::VoigtType::generic, "Same storage as stress (symmetric tensor)")
-        .value("none", simcoon::VoigtType::none, "Non-symmetric tensor, voigt() throws")
+        .value("stress", simcoon::Tensor2Type::stress, "Voigt = [s11, s22, s33, s12, s13, s23]")
+        .value("strain", simcoon::Tensor2Type::strain, "Voigt = [e11, e22, e33, 2*e12, 2*e13, 2*e23]")
+        .value("generic", simcoon::Tensor2Type::generic, "Same storage as stress (symmetric tensor)")
+        .value("none", simcoon::Tensor2Type::none, "Non-symmetric tensor, voigt() throws")
         .export_values();
+
+    // Deprecated pre-2.0 alias (see tensor.hpp)
+    m.attr("VoigtType") = m.attr("Tensor2Type");
 
     // Tensor4Type enum
     py::enum_<simcoon::Tensor4Type>(m, "Tensor4Type",
@@ -81,10 +84,10 @@ void register_tensor(py::module_& m) {
 
         // Constructors
         .def(py::init<>())
-        .def(py::init<simcoon::VoigtType>(), py::arg("vtype"))
+        .def(py::init<simcoon::Tensor2Type>(), py::arg("vtype"))
 
         .def_static("from_mat",
-            [](py::array_t<double> m, simcoon::VoigtType vtype) {
+            [](py::array_t<double> m, simcoon::Tensor2Type vtype) {
                 validate_matrix_size(m, 3, 3, "m");
                 mat m_cpp = carma::arr_to_mat(m);
                 return simcoon::tensor2(mat::fixed<3,3>(m_cpp), vtype);
@@ -93,7 +96,7 @@ void register_tensor(py::module_& m) {
             "Create tensor2 from a 3x3 numpy array")
 
         .def_static("from_voigt",
-            [](py::array_t<double> v, simcoon::VoigtType vtype) {
+            [](py::array_t<double> v, simcoon::Tensor2Type vtype) {
                 validate_vector_size(v, 6, "v");
                 vec v_cpp = carma::arr_to_col(v);
                 return simcoon::tensor2::from_voigt(vec::fixed<6>(v_cpp.memptr()), vtype);
@@ -102,7 +105,7 @@ void register_tensor(py::module_& m) {
             "Create tensor2 from a 6-element Voigt vector")
 
         .def_static("from_mandel",
-            [](py::array_t<double> v, simcoon::VoigtType vtype) {
+            [](py::array_t<double> v, simcoon::Tensor2Type vtype) {
                 validate_vector_size(v, 6, "v");
                 vec v_cpp = carma::arr_to_col(v);
                 return simcoon::tensor2::from_mandel(vec::fixed<6>(v_cpp.memptr()), vtype);
@@ -111,12 +114,12 @@ void register_tensor(py::module_& m) {
             "Create tensor2 from a Kelvin-Mandel 6-vector (sqrt2 on shear, type-independent)")
 
         .def_static("zeros",
-            static_cast<simcoon::tensor2 (*)(simcoon::VoigtType)>(&simcoon::tensor2::zeros),
-            py::arg("vtype") = simcoon::VoigtType::stress)
+            static_cast<simcoon::tensor2 (*)(simcoon::Tensor2Type)>(&simcoon::tensor2::zeros),
+            py::arg("vtype") = simcoon::Tensor2Type::stress)
 
         .def_static("identity",
-            static_cast<simcoon::tensor2 (*)(simcoon::VoigtType)>(&simcoon::tensor2::identity),
-            py::arg("vtype") = simcoon::VoigtType::stress)
+            static_cast<simcoon::tensor2 (*)(simcoon::Tensor2Type)>(&simcoon::tensor2::identity),
+            py::arg("vtype") = simcoon::Tensor2Type::stress)
 
         // Properties
         .def_property_readonly("mat",
@@ -185,10 +188,10 @@ void register_tensor(py::module_& m) {
         .def("__repr__", [](const simcoon::tensor2& self) {
             string vtype_str;
             switch (self.vtype()) {
-                case simcoon::VoigtType::stress: vtype_str = "stress"; break;
-                case simcoon::VoigtType::strain: vtype_str = "strain"; break;
-                case simcoon::VoigtType::generic: vtype_str = "generic"; break;
-                case simcoon::VoigtType::none: vtype_str = "none"; break;
+                case simcoon::Tensor2Type::stress: vtype_str = "stress"; break;
+                case simcoon::Tensor2Type::strain: vtype_str = "strain"; break;
+                case simcoon::Tensor2Type::generic: vtype_str = "generic"; break;
+                case simcoon::Tensor2Type::none: vtype_str = "none"; break;
             }
             return "Tensor2(vtype=" + vtype_str + ")";
         });
@@ -332,7 +335,7 @@ void register_tensor(py::module_& m) {
 
     m.def("_batch_rotate",
         [](
-           py::array_t<double> voigt, simcoon::VoigtType vtype,
+           py::array_t<double> voigt, simcoon::Tensor2Type vtype,
            py::array_t<double> rot_matrices, bool active) {
             mat v_cpp = np2d_to_mat6N(voigt);
             cube r_cpp = carma::arr_to_cube<double>(rot_matrices);
@@ -347,7 +350,7 @@ void register_tensor(py::module_& m) {
 
     m.def("_batch_push_forward",
         [](
-           py::array_t<double> voigt, simcoon::VoigtType vtype,
+           py::array_t<double> voigt, simcoon::Tensor2Type vtype,
            py::array_t<double> F_arr, bool metric) {
             mat v_cpp = np2d_to_mat6N(voigt);
             cube f_cpp = carma::arr_to_cube<double>(F_arr);
@@ -362,7 +365,7 @@ void register_tensor(py::module_& m) {
 
     m.def("_batch_pull_back",
         [](
-           py::array_t<double> voigt, simcoon::VoigtType vtype,
+           py::array_t<double> voigt, simcoon::Tensor2Type vtype,
            py::array_t<double> F_arr, bool metric) {
             mat v_cpp = np2d_to_mat6N(voigt);
             cube f_cpp = carma::arr_to_cube<double>(F_arr);
@@ -376,7 +379,7 @@ void register_tensor(py::module_& m) {
         py::arg("voigt"), py::arg("vtype"), py::arg("F"), py::arg("metric") = true);
 
     m.def("_batch_mises",
-        [](py::array_t<double> voigt, simcoon::VoigtType vtype) {
+        [](py::array_t<double> voigt, simcoon::Tensor2Type vtype) {
             mat v_cpp = np2d_to_mat6N(voigt);
             vec result = simcoon::batch_mises(v_cpp, vtype);
             return carma::col_to_arr(result);
@@ -384,7 +387,7 @@ void register_tensor(py::module_& m) {
         py::arg("voigt"), py::arg("vtype"));
 
     m.def("_batch_trace",
-        [](py::array_t<double> voigt, simcoon::VoigtType vtype) {
+        [](py::array_t<double> voigt, simcoon::Tensor2Type vtype) {
             mat v_cpp = np2d_to_mat6N(voigt);
             vec result = simcoon::batch_trace(v_cpp, vtype);
             return carma::col_to_arr(result);
@@ -394,7 +397,7 @@ void register_tensor(py::module_& m) {
     m.def("_batch_contract",
         [](
            py::array_t<double> t4_arr, simcoon::Tensor4Type t4type,
-           py::array_t<double> t2_arr, simcoon::VoigtType t2_vtype) {
+           py::array_t<double> t2_arr, simcoon::Tensor2Type t2_vtype) {
             cube t4_cpp = carma::arr_to_cube<double>(t4_arr);
             mat t2_cpp = np2d_to_mat6N(t2_arr);
             mat result;
@@ -402,7 +405,7 @@ void register_tensor(py::module_& m) {
                 py::gil_scoped_release release;
                 result = simcoon::batch_contract(t4_cpp, t4type, t2_cpp, t2_vtype);
             }
-            simcoon::VoigtType out_vtype = simcoon::infer_contraction_vtype(t4type);
+            simcoon::Tensor2Type out_vtype = simcoon::infer_contraction_vtype(t4type);
             return py::make_tuple(mat6N_to_np2d(result), out_vtype);
         },
         py::arg("t4"), py::arg("t4type"), py::arg("t2"), py::arg("t2_vtype"));

--- a/src/Continuum_mechanics/Functions/tensor.cpp
+++ b/src/Continuum_mechanics/Functions/tensor.cpp
@@ -36,13 +36,13 @@
 
 namespace simcoon {
 
-// Helper: string → VoigtType
-static VoigtType parse_voigt_type(const std::string &s) {
-    if (s == "stress")  return VoigtType::stress;
-    if (s == "strain")  return VoigtType::strain;
-    if (s == "generic") return VoigtType::generic;
-    if (s == "none")    return VoigtType::none;
-    throw std::invalid_argument("Unknown VoigtType string: '" + s + "'. "
+// Helper: string → Tensor2Type
+static Tensor2Type parse_voigt_type(const std::string &s) {
+    if (s == "stress")  return Tensor2Type::stress;
+    if (s == "strain")  return Tensor2Type::strain;
+    if (s == "generic") return Tensor2Type::generic;
+    if (s == "none")    return Tensor2Type::none;
+    throw std::invalid_argument("Unknown Tensor2Type string: '" + s + "'. "
         "Expected: stress, strain, generic, none");
 }
 
@@ -178,14 +178,14 @@ static arma::mat::fixed<6,6> base_volumetric() {
 // tensor2 implementation
 // ============================================================================
 
-tensor2::tensor2() : _mat(arma::fill::zeros), _vtype(VoigtType::stress) {}
+tensor2::tensor2() : _mat(arma::fill::zeros), _vtype(Tensor2Type::stress) {}
 
-tensor2::tensor2(VoigtType vtype) : _mat(arma::fill::zeros), _vtype(vtype) {}
+tensor2::tensor2(Tensor2Type vtype) : _mat(arma::fill::zeros), _vtype(vtype) {}
 
-tensor2::tensor2(const arma::mat::fixed<3,3> &m, VoigtType vtype)
+tensor2::tensor2(const arma::mat::fixed<3,3> &m, Tensor2Type vtype)
     : _mat(m), _vtype(vtype) {}
 
-tensor2::tensor2(const arma::mat &m, VoigtType vtype)
+tensor2::tensor2(const arma::mat &m, Tensor2Type vtype)
     : _vtype(vtype) {
     if (m.n_rows != 3 || m.n_cols != 3)
         throw std::invalid_argument("tensor2: expected 3x3 matrix, got "
@@ -193,26 +193,26 @@ tensor2::tensor2(const arma::mat &m, VoigtType vtype)
     _mat = m;
 }
 
-tensor2 tensor2::from_voigt(const arma::vec::fixed<6> &v, VoigtType vtype) {
+tensor2 tensor2::from_voigt(const arma::vec::fixed<6> &v, Tensor2Type vtype) {
     arma::mat::fixed<3,3> m;
-    if (vtype == VoigtType::strain) {
+    if (vtype == Tensor2Type::strain) {
         m(0,0) = v(0); m(1,1) = v(1); m(2,2) = v(2);
         m(0,1) = 0.5 * v(3); m(1,0) = 0.5 * v(3);
         m(0,2) = 0.5 * v(4); m(2,0) = 0.5 * v(4);
         m(1,2) = 0.5 * v(5); m(2,1) = 0.5 * v(5);
-    } else if (vtype == VoigtType::stress || vtype == VoigtType::generic) {
+    } else if (vtype == Tensor2Type::stress || vtype == Tensor2Type::generic) {
         m(0,0) = v(0); m(1,1) = v(1); m(2,2) = v(2);
         m(0,1) = v(3); m(1,0) = v(3);
         m(0,2) = v(4); m(2,0) = v(4);
         m(1,2) = v(5); m(2,1) = v(5);
     } else {
-        throw std::runtime_error("Cannot construct tensor2 from Voigt with VoigtType::none");
+        throw std::runtime_error("Cannot construct tensor2 from Voigt with Tensor2Type::none");
     }
     tensor2 result(m, vtype);
     return result;
 }
 
-tensor2 tensor2::from_voigt(const arma::vec &v, VoigtType vtype) {
+tensor2 tensor2::from_voigt(const arma::vec &v, Tensor2Type vtype) {
     if (v.n_elem != 6)
         throw std::invalid_argument("tensor2: expected 6-element vector, got "
             + std::to_string(v.n_elem));
@@ -224,7 +224,7 @@ tensor2 tensor2::from_voigt(const arma::vec &v, const std::string &type_str) {
     return from_voigt(v, parse_voigt_type(type_str));
 }
 
-tensor2 tensor2::from_mandel(const arma::vec::fixed<6> &v, VoigtType vtype) {
+tensor2 tensor2::from_mandel(const arma::vec::fixed<6> &v, Tensor2Type vtype) {
     // Mandel shear = sqrt2 * true component, identical for stress and strain.
     arma::mat::fixed<3,3> m;
     m(0,0) = v(0); m(1,1) = v(1); m(2,2) = v(2);
@@ -234,7 +234,7 @@ tensor2 tensor2::from_mandel(const arma::vec::fixed<6> &v, VoigtType vtype) {
     return tensor2(m, vtype);
 }
 
-tensor2 tensor2::zeros(VoigtType vtype) {
+tensor2 tensor2::zeros(Tensor2Type vtype) {
     return tensor2(vtype);
 }
 
@@ -242,7 +242,7 @@ tensor2 tensor2::zeros(const std::string &type_str) {
     return zeros(parse_voigt_type(type_str));
 }
 
-tensor2 tensor2::identity(VoigtType vtype) {
+tensor2 tensor2::identity(Tensor2Type vtype) {
     return tensor2(arma::mat::fixed<3,3>(arma::fill::eye), vtype);
 }
 
@@ -269,18 +269,18 @@ void tensor2::set_mat(const arma::mat &m) {
 }
 
 void tensor2::set_voigt(const arma::vec::fixed<6> &v) {
-    if (_vtype == VoigtType::strain) {
+    if (_vtype == Tensor2Type::strain) {
         _mat(0,0) = v(0); _mat(1,1) = v(1); _mat(2,2) = v(2);
         _mat(0,1) = 0.5 * v(3); _mat(1,0) = 0.5 * v(3);
         _mat(0,2) = 0.5 * v(4); _mat(2,0) = 0.5 * v(4);
         _mat(1,2) = 0.5 * v(5); _mat(2,1) = 0.5 * v(5);
-    } else if (_vtype == VoigtType::stress || _vtype == VoigtType::generic) {
+    } else if (_vtype == Tensor2Type::stress || _vtype == Tensor2Type::generic) {
         _mat(0,0) = v(0); _mat(1,1) = v(1); _mat(2,2) = v(2);
         _mat(0,1) = v(3); _mat(1,0) = v(3);
         _mat(0,2) = v(4); _mat(2,0) = v(4);
         _mat(1,2) = v(5); _mat(2,1) = v(5);
     } else {
-        throw std::runtime_error("Cannot set_voigt on VoigtType::none tensor");
+        throw std::runtime_error("Cannot set_voigt on Tensor2Type::none tensor");
     }
 }
 
@@ -293,14 +293,14 @@ void tensor2::set_voigt(const arma::vec &v) {
 }
 
 arma::vec::fixed<6> tensor2::voigt() const {
-    if (_vtype == VoigtType::none) {
-        throw std::runtime_error("Cannot compute Voigt vector for VoigtType::none (non-symmetric tensor)");
+    if (_vtype == Tensor2Type::none) {
+        throw std::runtime_error("Cannot compute Voigt vector for Tensor2Type::none (non-symmetric tensor)");
     }
 
     arma::vec::fixed<6> v;
     v(0) = _mat(0,0); v(1) = _mat(1,1); v(2) = _mat(2,2);
 
-    if (_vtype == VoigtType::strain) {
+    if (_vtype == Tensor2Type::strain) {
         v(3) = _mat(0,1) + _mat(1,0);
         v(4) = _mat(0,2) + _mat(2,0);
         v(5) = _mat(1,2) + _mat(2,1);
@@ -313,8 +313,8 @@ arma::vec::fixed<6> tensor2::voigt() const {
 }
 
 arma::vec::fixed<6> tensor2::mandel() const {
-    if (_vtype == VoigtType::none) {
-        throw std::runtime_error("Cannot compute Mandel vector for VoigtType::none (non-symmetric tensor)");
+    if (_vtype == Tensor2Type::none) {
+        throw std::runtime_error("Cannot compute Mandel vector for Tensor2Type::none (non-symmetric tensor)");
     }
     // Mandel shear = sqrt2 * true component (= sqrt2 * symmetric part), same for stress/strain.
     arma::vec::fixed<6> v;
@@ -326,7 +326,7 @@ arma::vec::fixed<6> tensor2::mandel() const {
 }
 
 Fastor::Tensor<double,3,3> tensor2::fastor() const {
-    return arma_to_fastor2(_mat, _vtype != VoigtType::none);
+    return arma_to_fastor2(_mat, _vtype != Tensor2Type::none);
 }
 
 bool tensor2::is_symmetric(double tol) const {
@@ -337,7 +337,7 @@ bool tensor2::is_symmetric(double tol) const {
 
 tensor2 tensor2::rotate(const Rotation &R, bool active) const {
     // The 3x3 holds the true tensor, so a single full-index rotation Q*X*Q^T covers every
-    // VoigtType (stress, strain, generic, non-symmetric). Q orthogonal => exact for all.
+    // Tensor2Type (stress, strain, generic, non-symmetric). Q orthogonal => exact for all.
     arma::mat::fixed<3,3> Q = R.as_matrix();
     if (!active) Q = arma::mat::fixed<3,3>(Q.t());
     arma::mat::fixed<3,3> result = Q * _mat * Q.t();
@@ -346,32 +346,32 @@ tensor2 tensor2::rotate(const Rotation &R, bool active) const {
 
 tensor2 tensor2::push_forward(const arma::mat::fixed<3,3> &F, bool metric) const {
     switch (_vtype) {
-        case VoigtType::stress: {
+        case Tensor2Type::stress: {
             arma::mat::fixed<3,3> result;
             result = F * _mat * F.t();
             if (metric) {
                 double J = arma::det(F);
                 result *= (1.0 / J);
             }
-            return tensor2(result, VoigtType::stress);
+            return tensor2(result, Tensor2Type::stress);
         }
-        case VoigtType::strain: {
+        case Tensor2Type::strain: {
             arma::mat::fixed<3,3> invF = inv33(F);
             arma::mat::fixed<3,3> result;
             result = invF.t() * _mat * invF;
             // strain factor is 1 — no metric correction needed
-            return tensor2(result, VoigtType::strain);
+            return tensor2(result, Tensor2Type::strain);
         }
-        case VoigtType::generic:
-        case VoigtType::none:
-            throw std::runtime_error("push_forward requires VoigtType::stress or VoigtType::strain");
+        case Tensor2Type::generic:
+        case Tensor2Type::none:
+            throw std::runtime_error("push_forward requires Tensor2Type::stress or Tensor2Type::strain");
     }
     return *this;
 }
 
 tensor2 tensor2::pull_back(const arma::mat::fixed<3,3> &F, bool metric) const {
     switch (_vtype) {
-        case VoigtType::stress: {
+        case Tensor2Type::stress: {
             arma::mat::fixed<3,3> invF = inv33(F);
             arma::mat::fixed<3,3> result;
             result = invF * _mat * invF.t();
@@ -379,17 +379,17 @@ tensor2 tensor2::pull_back(const arma::mat::fixed<3,3> &F, bool metric) const {
                 double J = arma::det(F);
                 result *= J;
             }
-            return tensor2(result, VoigtType::stress);
+            return tensor2(result, Tensor2Type::stress);
         }
-        case VoigtType::strain: {
+        case Tensor2Type::strain: {
             arma::mat::fixed<3,3> result;
             result = F.t() * _mat * F;
             // strain factor is 1 — no metric correction needed
-            return tensor2(result, VoigtType::strain);
+            return tensor2(result, Tensor2Type::strain);
         }
-        case VoigtType::generic:
-        case VoigtType::none:
-            throw std::runtime_error("pull_back requires VoigtType::stress or VoigtType::strain");
+        case Tensor2Type::generic:
+        case Tensor2Type::none:
+            throw std::runtime_error("pull_back requires Tensor2Type::stress or Tensor2Type::strain");
     }
     return *this;
 }
@@ -492,35 +492,35 @@ bool tensor2::operator!=(const tensor2 &other) const {
 
 // Free functions
 tensor2 stress(const arma::mat::fixed<3,3> &m) {
-    return tensor2(m, VoigtType::stress);
+    return tensor2(m, Tensor2Type::stress);
 }
 
 tensor2 stress(const arma::vec::fixed<6> &v) {
-    return tensor2::from_voigt(v, VoigtType::stress);
+    return tensor2::from_voigt(v, Tensor2Type::stress);
 }
 
 tensor2 stress(const arma::mat &m) {
-    return tensor2(m, VoigtType::stress);
+    return tensor2(m, Tensor2Type::stress);
 }
 
 tensor2 stress(const arma::vec &v) {
-    return tensor2::from_voigt(v, VoigtType::stress);
+    return tensor2::from_voigt(v, Tensor2Type::stress);
 }
 
 tensor2 strain(const arma::mat::fixed<3,3> &m) {
-    return tensor2(m, VoigtType::strain);
+    return tensor2(m, Tensor2Type::strain);
 }
 
 tensor2 strain(const arma::vec::fixed<6> &v) {
-    return tensor2::from_voigt(v, VoigtType::strain);
+    return tensor2::from_voigt(v, Tensor2Type::strain);
 }
 
 tensor2 strain(const arma::mat &m) {
-    return tensor2(m, VoigtType::strain);
+    return tensor2(m, Tensor2Type::strain);
 }
 
 tensor2 strain(const arma::vec &v) {
-    return tensor2::from_voigt(v, VoigtType::strain);
+    return tensor2::from_voigt(v, Tensor2Type::strain);
 }
 
 tensor2 dev(const tensor2 &t) {
@@ -532,8 +532,8 @@ tensor2 dev(const tensor2 &t) {
 }
 
 double Mises(const tensor2 &t) {
-    if (t.vtype() == VoigtType::none)
-        throw std::runtime_error("Mises not defined for VoigtType::none");
+    if (t.vtype() == Tensor2Type::none)
+        throw std::runtime_error("Mises not defined for Tensor2Type::none");
     // From the 3x3 deviator (convention-free): stress -> sqrt(3/2 dev:dev),
     // strain -> sqrt(2/3 dev:dev). accu(dev % dev) is the double contraction (off-diagonals
     // counted twice via symmetry), so no engineering shear factors are needed.
@@ -541,7 +541,7 @@ double Mises(const tensor2 &t) {
     double tr = (d(0,0) + d(1,1) + d(2,2)) / 3.0;
     d(0,0) -= tr; d(1,1) -= tr; d(2,2) -= tr;
     double dd = arma::accu(d % d);
-    if (t.vtype() == VoigtType::strain)
+    if (t.vtype() == Tensor2Type::strain)
         return std::sqrt((2.0/3.0) * dd);
     return std::sqrt(1.5 * dd);
 }
@@ -557,7 +557,7 @@ static tensor2 dp_surface_normal(const tensor2 &sigma, double coeff) {
     if (seq > simcoon::iota) n *= (1.5 / seq);            // (3/2) s / s_eq
     else                     n.zeros();
     n(0,0) += coeff; n(1,1) += coeff; n(2,2) += coeff;
-    return tensor2(n, VoigtType::strain);
+    return tensor2(n, Tensor2Type::strain);
 }
 
 tensor2 flow_normal(const tensor2 &sigma, double alpha) {
@@ -949,17 +949,17 @@ tensor4 auto_dyadic(const tensor2 &a) {
 // Batch operations
 // ============================================================================
 
-VoigtType infer_contraction_vtype(Tensor4Type t4type) {
+Tensor2Type infer_contraction_vtype(Tensor4Type t4type) {
     switch (t4type) {
         case Tensor4Type::stiffness:
         case Tensor4Type::stress_concentration:
         case Tensor4Type::generic:
-            return VoigtType::stress;
+            return Tensor2Type::stress;
         case Tensor4Type::compliance:
         case Tensor4Type::strain_concentration:
-            return VoigtType::strain;
+            return Tensor2Type::strain;
     }
-    return VoigtType::stress;
+    return Tensor2Type::stress;
 }
 
 Tensor4Type infer_inverse_type(Tensor4Type t4type) {
@@ -990,7 +990,7 @@ static arma::vec::fixed<6> col_fixed6(const arma::mat &m, arma::uword j) {
     return v;
 }
 
-arma::mat batch_rotate(const arma::mat &voigt, VoigtType vtype,
+arma::mat batch_rotate(const arma::mat &voigt, Tensor2Type vtype,
                        const arma::cube &rot_matrices, bool active) {
     int N = voigt.n_cols;
     check_batch_broadcast(rot_matrices.n_slices, N,
@@ -1006,7 +1006,7 @@ arma::mat batch_rotate(const arma::mat &voigt, VoigtType vtype,
     return result;
 }
 
-arma::mat batch_push_forward(const arma::mat &voigt, VoigtType vtype,
+arma::mat batch_push_forward(const arma::mat &voigt, Tensor2Type vtype,
                              const arma::cube &F, bool metric) {
     int N = voigt.n_cols;
     check_batch_broadcast(F.n_slices, N,
@@ -1022,7 +1022,7 @@ arma::mat batch_push_forward(const arma::mat &voigt, VoigtType vtype,
     return result;
 }
 
-arma::mat batch_pull_back(const arma::mat &voigt, VoigtType vtype,
+arma::mat batch_pull_back(const arma::mat &voigt, Tensor2Type vtype,
                           const arma::cube &F, bool metric) {
     int N = voigt.n_cols;
     check_batch_broadcast(F.n_slices, N,
@@ -1038,7 +1038,7 @@ arma::mat batch_pull_back(const arma::mat &voigt, VoigtType vtype,
     return result;
 }
 
-arma::vec batch_mises(const arma::mat &voigt, VoigtType vtype) {
+arma::vec batch_mises(const arma::mat &voigt, Tensor2Type vtype) {
     // Stress: sqrt(3/2 * (diag^2 + 2*shear^2))
     // Strain: sqrt(2/3 * (diag^2 + 0.5*shear^2))  (shear Voigt = 2*eij)
     arma::mat dev = voigt;
@@ -1050,19 +1050,19 @@ arma::vec batch_mises(const arma::mat &voigt, VoigtType vtype) {
     arma::rowvec diag2 = arma::sum(dev.rows(0,2) % dev.rows(0,2), 0);
     arma::rowvec shear2 = arma::sum(dev.rows(3,5) % dev.rows(3,5), 0);
 
-    if (vtype == VoigtType::strain) {
+    if (vtype == Tensor2Type::strain) {
         return arma::sqrt((2.0/3.0) * (diag2 + 0.5 * shear2)).t();
     }
     return arma::sqrt(1.5 * (diag2 + 2.0 * shear2)).t();
 }
 
-arma::vec batch_trace(const arma::mat &voigt, VoigtType /*vtype*/) {
-    // trace = v(0) + v(1) + v(2) regardless of VoigtType
+arma::vec batch_trace(const arma::mat &voigt, Tensor2Type /*vtype*/) {
+    // trace = v(0) + v(1) + v(2) regardless of Tensor2Type
     return arma::vectorise(voigt.row(0) + voigt.row(1) + voigt.row(2));
 }
 
 arma::mat batch_contract(const arma::cube &t4, Tensor4Type t4type,
-                         const arma::mat &t2, VoigtType t2_vtype) {
+                         const arma::mat &t2, Tensor2Type t2_vtype) {
     int N4 = t4.n_slices;
     int N2 = t2.n_cols;
     int N = std::max(N4, N2);

--- a/src/Continuum_mechanics/Umat/Modular/damage_mechanism.cpp
+++ b/src/Continuum_mechanics/Umat/Modular/damage_mechanism.cpp
@@ -227,7 +227,7 @@ const std::vector<tensor2>& DamageMechanism::dPhi_dsigma(
     // M_cached_ is populated by compute_constraints (must be called first).
     dPhi_dsigma_cache_[0] = M_cached_valid_
         ? strain(arma::vec(M_cached_ * sigma))
-        : tensor2::zeros(VoigtType::strain);
+        : tensor2::zeros(Tensor2Type::strain);
     return dPhi_dsigma_cache_;
 }
 
@@ -245,7 +245,7 @@ const std::vector<tensor2>& DamageMechanism::kappa(
         const double factor = 1.0 / ((1.0 - D) * (1.0 - D));
         kappa_cache_[0] = strain(arma::vec(factor * (M_cached_ * sigma)));
     } else {
-        kappa_cache_[0] = tensor2::zeros(VoigtType::strain);
+        kappa_cache_[0] = tensor2::zeros(Tensor2Type::strain);
     }
     return kappa_cache_;
 }

--- a/src/Continuum_mechanics/Umat/Modular/hardening.cpp
+++ b/src/Continuum_mechanics/Umat/Modular/hardening.cpp
@@ -186,7 +186,7 @@ void PragerHardening::register_variables(InternalVariableCollection& ivc) {
 
 void PragerHardening::compute_backstresses(const InternalVariableCollection& ivc,
                                            std::vector<tensor2>& X_i) const {
-    X_i.resize(1, tensor2(VoigtType::stress));
+    X_i.resize(1, tensor2(Tensor2Type::stress));
     X_i[0] = backstress_t(C_, ivc.get(a_key_).as_tensor2());
 }
 
@@ -224,7 +224,7 @@ void ArmstrongFrederickHardening::register_variables(InternalVariableCollection&
 
 void ArmstrongFrederickHardening::compute_backstresses(
     const InternalVariableCollection& ivc, std::vector<tensor2>& X_i) const {
-    X_i.resize(1, tensor2(VoigtType::stress));
+    X_i.resize(1, tensor2(Tensor2Type::stress));
     X_i[0] = backstress_t(C_, ivc.get(a_key_).as_tensor2());
 }
 
@@ -275,7 +275,7 @@ void ChabocheHardening::compute_backstresses(const InternalVariableCollection& i
     // X_i = (2/3) C_i α_i, STRESS-typed (backstress_t re-tags through the 3x3;
     // a strain-typed carrier would put the factor-2 shear back — wrong under
     // any loading with shear).
-    X_i.resize(static_cast<size_t>(N_), tensor2(VoigtType::stress));
+    X_i.resize(static_cast<size_t>(N_), tensor2(Tensor2Type::stress));
     for (int i = 0; i < N_; ++i) {
         X_i[static_cast<size_t>(i)] = backstress_t(C_(i), ivc.get(a_keys_[i]).as_tensor2());
     }

--- a/src/Continuum_mechanics/Umat/Modular/internal_variable.cpp
+++ b/src/Continuum_mechanics/Umat/Modular/internal_variable.cpp
@@ -37,14 +37,14 @@ InternalVariable::InternalVariable(const std::string& name, double init)
     , mat_value_()
     , mat_start_()
     , is_objective_(true)   // scalars are always objective (frame-invariant)
-    , vtype_(VoigtType::strain)
+    , vtype_(Tensor2Type::strain)
     , t4type_(Tensor4Type::stiffness)
     , statev_offset_(0)
 {
 }
 
 InternalVariable::InternalVariable(const std::string& name, const arma::vec& init,
-                                    bool objective, VoigtType vtype)
+                                    bool objective, Tensor2Type vtype)
     : name_(name)
     , type_(IVarType::VECTOR_6)
     , scalar_value_(0.0)
@@ -75,7 +75,7 @@ InternalVariable::InternalVariable(const std::string& name, const arma::mat& ini
     , mat_value_(init.n_rows == 6 && init.n_cols == 6 ? init : arma::zeros(6, 6))
     , mat_start_(init.n_rows == 6 && init.n_cols == 6 ? init : arma::zeros(6, 6))
     , is_objective_(objective)
-    , vtype_(VoigtType::strain)
+    , vtype_(Tensor2Type::strain)
     , t4type_(t4type)
     , statev_offset_(0)
 {
@@ -233,7 +233,7 @@ void InternalVariable::rotate(const Rotation& R) {
         case IVarType::VECTOR_6: {
             // Route through tensor2 so the rotation kernel (apply_strain vs
             // apply_stress, and the future generic path) is chosen once, inside
-            // tensor2::rotate, from the variable's authoritative VoigtType.
+            // tensor2::rotate, from the variable's authoritative Tensor2Type.
             const tensor2 t = tensor2::from_voigt(vec_value_, vtype_).rotate(R);
             vec_value_ = t.to_arma_voigt();
             break;
@@ -249,7 +249,7 @@ void InternalVariable::rotate(const Rotation& R) {
 
 // ========== Tensor-typed views ==========
 
-tensor2 InternalVariable::as_tensor2(VoigtType vtype) const {
+tensor2 InternalVariable::as_tensor2(Tensor2Type vtype) const {
     if (type_ != IVarType::VECTOR_6) {
         throw std::runtime_error("InternalVariable::as_tensor2: variable '" + name_
                                  + "' is not VECTOR_6");
@@ -257,7 +257,7 @@ tensor2 InternalVariable::as_tensor2(VoigtType vtype) const {
     return tensor2::from_voigt(vec_value_, vtype);
 }
 
-tensor2 InternalVariable::as_tensor2_start(VoigtType vtype) const {
+tensor2 InternalVariable::as_tensor2_start(Tensor2Type vtype) const {
     if (type_ != IVarType::VECTOR_6) {
         throw std::runtime_error("InternalVariable::as_tensor2_start: variable '" + name_
                                  + "' is not VECTOR_6");

--- a/src/Continuum_mechanics/Umat/Modular/internal_variable_collection.cpp
+++ b/src/Continuum_mechanics/Umat/Modular/internal_variable_collection.cpp
@@ -43,7 +43,7 @@ InternalVariable& InternalVariableCollection::add_scalar(const std::string& name
 
 InternalVariable& InternalVariableCollection::add_vec(
     const std::string& name, const arma::vec& init,
-    bool objective, VoigtType vtype) {
+    bool objective, Tensor2Type vtype) {
     if (has(name)) {
         throw std::runtime_error("InternalVariableCollection: variable '" + name + "' already exists");
     }

--- a/src/Continuum_mechanics/Umat/Modular/plasticity_mechanism.cpp
+++ b/src/Continuum_mechanics/Umat/Modular/plasticity_mechanism.cpp
@@ -143,7 +143,7 @@ void PlasticityMechanism::compute_constraints(
     double sigma_eq;
     if (has_kin) {
         kin_hard_->compute_backstresses(ivc_, X_branches_);
-        tensor2 X_t = tensor2::zeros(VoigtType::stress);
+        tensor2 X_t = tensor2::zeros(Tensor2Type::stress);
         for (const auto& x : X_branches_) {
             X_t += x;
         }

--- a/src/Continuum_mechanics/Umat/Modular/viscoelastic_mechanism.cpp
+++ b/src/Continuum_mechanics/Umat/Modular/viscoelastic_mechanism.cpp
@@ -47,7 +47,7 @@ ViscoelasticMechanism::ViscoelasticMechanism(int N_prony)
     , flow_i_(N_prony)
     , Lambda_i_(N_prony)
     , kappa_i_(N_prony)
-    , kappa_t_(N_prony, tensor2(VoigtType::stress))
+    , kappa_t_(N_prony, tensor2(Tensor2Type::stress))
     , dPhi_i_dv_(N_prony)
     , K_diag_(arma::zeros(N_prony))
 {

--- a/test/Libraries/Continuum_mechanics/Ttensor.cpp
+++ b/test/Libraries/Continuum_mechanics/Ttensor.cpp
@@ -41,38 +41,38 @@ TEST(Ttensor2, DefaultConstructor)
 {
     tensor2 t;
     EXPECT_TRUE(arma::approx_equal(t.mat(), mat::fixed<3,3>(fill::zeros), "absdiff", 1e-15));
-    EXPECT_EQ(t.vtype(), VoigtType::stress);
+    EXPECT_EQ(t.vtype(), Tensor2Type::stress);
 }
 
-TEST(Ttensor2, VoigtTypeConstructor)
+TEST(Ttensor2, Tensor2TypeConstructor)
 {
-    tensor2 t(VoigtType::strain);
+    tensor2 t(Tensor2Type::strain);
     EXPECT_TRUE(arma::approx_equal(t.mat(), mat::fixed<3,3>(fill::zeros), "absdiff", 1e-15));
-    EXPECT_EQ(t.vtype(), VoigtType::strain);
+    EXPECT_EQ(t.vtype(), Tensor2Type::strain);
 }
 
 TEST(Ttensor2, MatrixConstructor)
 {
     mat::fixed<3,3> m = {{1, 2, 3}, {2, 5, 6}, {3, 6, 9}};
-    tensor2 t(m, VoigtType::stress);
+    tensor2 t(m, Tensor2Type::stress);
     EXPECT_TRUE(arma::approx_equal(t.mat(), m, "absdiff", 1e-15));
 }
 
 TEST(Ttensor2, DynamicMatConstructor)
 {
     mat m = {{1, 2, 3}, {2, 5, 6}, {3, 6, 9}};
-    tensor2 t(m, VoigtType::stress);
+    tensor2 t(m, Tensor2Type::stress);
     mat::fixed<3,3> expected = {{1, 2, 3}, {2, 5, 6}, {3, 6, 9}};
     EXPECT_TRUE(arma::approx_equal(t.mat(), expected, "absdiff", 1e-15));
 }
 
 TEST(Ttensor2, Factories)
 {
-    tensor2 z = tensor2::zeros(VoigtType::strain);
+    tensor2 z = tensor2::zeros(Tensor2Type::strain);
     EXPECT_TRUE(arma::approx_equal(z.mat(), mat::fixed<3,3>(fill::zeros), "absdiff", 1e-15));
-    EXPECT_EQ(z.vtype(), VoigtType::strain);
+    EXPECT_EQ(z.vtype(), Tensor2Type::strain);
 
-    tensor2 id = tensor2::identity(VoigtType::stress);
+    tensor2 id = tensor2::identity(Tensor2Type::stress);
     EXPECT_TRUE(arma::approx_equal(id.mat(), mat::fixed<3,3>(fill::eye), "absdiff", 1e-15));
 }
 
@@ -84,7 +84,7 @@ TEST(Ttensor2, StressVoigtMatchesTransfer)
 {
     // Create a symmetric stress tensor
     mat::fixed<3,3> sigma = {{100, 30, 20}, {30, 200, 40}, {20, 40, 300}};
-    tensor2 t(sigma, VoigtType::stress);
+    tensor2 t(sigma, Tensor2Type::stress);
 
     vec::fixed<6> v = t.voigt();
     vec v_ref = t2v_stress(mat(sigma));
@@ -96,7 +96,7 @@ TEST(Ttensor2, StrainVoigtMatchesTransfer)
 {
     // Create a symmetric strain tensor
     mat::fixed<3,3> eps = {{0.01, 0.005, 0.003}, {0.005, 0.02, 0.004}, {0.003, 0.004, 0.03}};
-    tensor2 t(eps, VoigtType::strain);
+    tensor2 t(eps, Tensor2Type::strain);
 
     vec::fixed<6> v = t.voigt();
     vec v_ref = t2v_strain(mat(eps));
@@ -107,7 +107,7 @@ TEST(Ttensor2, StrainVoigtMatchesTransfer)
 TEST(Ttensor2, FromVoigtStress)
 {
     vec::fixed<6> v = {100, 200, 300, 30, 20, 40};
-    tensor2 t = tensor2::from_voigt(v, VoigtType::stress);
+    tensor2 t = tensor2::from_voigt(v, Tensor2Type::stress);
 
     // Should reconstruct the matrix
     mat m_ref = v2t_stress(vec(v));
@@ -120,7 +120,7 @@ TEST(Ttensor2, FromVoigtStress)
 TEST(Ttensor2, FromVoigtStrain)
 {
     vec::fixed<6> v = {0.01, 0.02, 0.03, 0.01, 0.006, 0.008};
-    tensor2 t = tensor2::from_voigt(v, VoigtType::strain);
+    tensor2 t = tensor2::from_voigt(v, Tensor2Type::strain);
 
     // Should reconstruct the matrix (shear halved in matrix form)
     mat m_ref = v2t_strain(vec(v));
@@ -133,7 +133,7 @@ TEST(Ttensor2, FromVoigtStrain)
 TEST(Ttensor2, VoigtThrowsForNone)
 {
     mat::fixed<3,3> F = {{1.1, 0.1, 0}, {0, 1, 0.05}, {0, 0, 0.95}};
-    tensor2 t(F, VoigtType::none);
+    tensor2 t(F, Tensor2Type::none);
     EXPECT_THROW(t.voigt(), std::runtime_error);
 }
 
@@ -143,7 +143,7 @@ TEST(Ttensor2, VoigtThrowsForNone)
 
 TEST(Ttensor2, SetVoigt)
 {
-    tensor2 t(VoigtType::stress);
+    tensor2 t(Tensor2Type::stress);
     vec::fixed<6> v = {100, 200, 300, 30, 20, 40};
     t.set_voigt(v);
     EXPECT_LT(norm(vec(t.voigt()) - vec(v), 2), 1e-12);
@@ -151,7 +151,7 @@ TEST(Ttensor2, SetVoigt)
 
 TEST(Ttensor2, SetMat)
 {
-    tensor2 t(VoigtType::stress);
+    tensor2 t(Tensor2Type::stress);
     mat::fixed<3,3> m = {{10, 3, 2}, {3, 20, 4}, {2, 4, 30}};
     t.set_mat(m);
     EXPECT_TRUE(arma::approx_equal(t.mat(), m, "absdiff", 1e-15));
@@ -164,11 +164,11 @@ TEST(Ttensor2, SetMat)
 TEST(Ttensor2, SymmetryCheck)
 {
     mat::fixed<3,3> sym = {{1, 2, 3}, {2, 5, 6}, {3, 6, 9}};
-    tensor2 ts(sym, VoigtType::stress);
+    tensor2 ts(sym, Tensor2Type::stress);
     EXPECT_TRUE(ts.is_symmetric());
 
     mat::fixed<3,3> nonsym = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
-    tensor2 tn(nonsym, VoigtType::none);
+    tensor2 tn(nonsym, Tensor2Type::none);
     EXPECT_FALSE(tn.is_symmetric());
 }
 
@@ -179,7 +179,7 @@ TEST(Ttensor2, SymmetryCheck)
 TEST(Ttensor2, FastorMap)
 {
     mat::fixed<3,3> m = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
-    tensor2 t(m, VoigtType::none);
+    tensor2 t(m, Tensor2Type::none);
 
     auto fmap = t.fastor();
     // Check a few elements (Fastor and armadillo are both column-major)
@@ -196,16 +196,16 @@ TEST(Ttensor2, StressStrainFreeFunctions)
 {
     mat::fixed<3,3> m = {{100, 30, 20}, {30, 200, 40}, {20, 40, 300}};
     tensor2 s = stress(m);
-    EXPECT_EQ(s.vtype(), VoigtType::stress);
+    EXPECT_EQ(s.vtype(), Tensor2Type::stress);
 
     tensor2 e = strain(m);
-    EXPECT_EQ(e.vtype(), VoigtType::strain);
+    EXPECT_EQ(e.vtype(), Tensor2Type::strain);
 }
 
 TEST(Ttensor2, Trace)
 {
     mat::fixed<3,3> m = {{100, 30, 20}, {30, 200, 40}, {20, 40, 300}};
-    tensor2 t(m, VoigtType::stress);
+    tensor2 t(m, Tensor2Type::stress);
     EXPECT_DOUBLE_EQ(trace(t), 600.0);
 }
 
@@ -213,9 +213,9 @@ TEST(Ttensor2, DevStress)
 {
     // Hydrostatic stress => deviatoric part is zero
     mat::fixed<3,3> hydro = {{100, 0, 0}, {0, 100, 0}, {0, 0, 100}};
-    tensor2 t(hydro, VoigtType::stress);
+    tensor2 t(hydro, Tensor2Type::stress);
     tensor2 d = dev(t);
-    EXPECT_EQ(d.vtype(), VoigtType::stress);
+    EXPECT_EQ(d.vtype(), Tensor2Type::stress);
     EXPECT_LT(norm(d), 1e-12);
 }
 
@@ -225,7 +225,7 @@ TEST(Ttensor2, Mises)
     double Y = 250.0;
     mat::fixed<3,3> tension = fill::zeros;
     tension(0,0) = Y;
-    tensor2 t(tension, VoigtType::stress);
+    tensor2 t(tension, Tensor2Type::stress);
     EXPECT_NEAR(Mises(t), Y, 1e-10);
 }
 
@@ -238,14 +238,14 @@ TEST(Ttensor2, SchurProduct)
     // operator% returns a tensor2 (element-wise on 3x3), like Armadillo
     mat::fixed<3,3> a_m = {{100, 30, 20}, {30, 200, 40}, {20, 40, 300}};
     mat::fixed<3,3> b_m = {{0.01, 0.005, 0.003}, {0.005, 0.02, 0.004}, {0.003, 0.004, 0.03}};
-    tensor2 a(a_m, VoigtType::stress);
-    tensor2 b(b_m, VoigtType::strain);
+    tensor2 a(a_m, Tensor2Type::stress);
+    tensor2 b(b_m, Tensor2Type::strain);
 
     tensor2 c = a % b;
     mat::fixed<3,3> expected;
     expected = a_m % b_m;
     EXPECT_TRUE(arma::approx_equal(c.mat(), expected, "absdiff", 1e-14));
-    EXPECT_EQ(c.vtype(), VoigtType::stress); // preserves left operand type
+    EXPECT_EQ(c.vtype(), Tensor2Type::stress); // preserves left operand type
 }
 
 TEST(Ttensor2, SumSchurWork)
@@ -259,8 +259,8 @@ TEST(Ttensor2, SumSchurWork)
     vec::fixed<6> eps_v = {0.01, -0.003, -0.003, 0.005, 0.002, 0.001};
     vec::fixed<6> sig_v = L * eps_v;
 
-    tensor2 sigma = tensor2::from_voigt(sig_v, VoigtType::stress);
-    tensor2 eps = tensor2::from_voigt(eps_v, VoigtType::strain);
+    tensor2 sigma = tensor2::from_voigt(sig_v, Tensor2Type::stress);
+    tensor2 eps = tensor2::from_voigt(eps_v, Tensor2Type::strain);
 
     double W_tensor = sum(sigma % eps);
     double W_voigt = dot(sig_v, eps_v);
@@ -276,8 +276,8 @@ TEST(Ttensor2, Addition)
 {
     mat::fixed<3,3> a = {{1, 2, 3}, {2, 5, 6}, {3, 6, 9}};
     mat::fixed<3,3> b = {{10, 20, 30}, {20, 50, 60}, {30, 60, 90}};
-    tensor2 ta(a, VoigtType::stress);
-    tensor2 tb(b, VoigtType::stress);
+    tensor2 ta(a, Tensor2Type::stress);
+    tensor2 tb(b, Tensor2Type::stress);
     tensor2 tc = ta + tb;
     mat::fixed<3,3> expected;
     expected = a + b;
@@ -287,7 +287,7 @@ TEST(Ttensor2, Addition)
 TEST(Ttensor2, ScalarMultiply)
 {
     mat::fixed<3,3> a = {{1, 2, 3}, {2, 5, 6}, {3, 6, 9}};
-    tensor2 ta(a, VoigtType::stress);
+    tensor2 ta(a, Tensor2Type::stress);
     tensor2 tb = ta * 3.0;
     tensor2 tc = 3.0 * ta;
     mat::fixed<3,3> expected;
@@ -299,9 +299,9 @@ TEST(Ttensor2, ScalarMultiply)
 TEST(Ttensor2, Equality)
 {
     mat::fixed<3,3> a = {{1, 2, 3}, {2, 5, 6}, {3, 6, 9}};
-    tensor2 ta(a, VoigtType::stress);
-    tensor2 tb(a, VoigtType::stress);
-    tensor2 tc(a, VoigtType::strain);
+    tensor2 ta(a, Tensor2Type::stress);
+    tensor2 tb(a, Tensor2Type::stress);
+    tensor2 tc(a, Tensor2Type::strain);
     EXPECT_TRUE(ta == tb);
     EXPECT_FALSE(ta == tc);
 }
@@ -314,7 +314,7 @@ TEST(Ttensor2, RotationStressRoundtrip)
 {
     // Rotate a stress tensor by some angle and back: should recover original
     mat::fixed<3,3> sigma = {{100, 30, 20}, {30, 200, 40}, {20, 40, 300}};
-    tensor2 t(sigma, VoigtType::stress);
+    tensor2 t(sigma, Tensor2Type::stress);
 
     Rotation R = Rotation::from_euler(0.3, 0.5, 0.7, "zxz");
     tensor2 t_rot = t.rotate(R, true);
@@ -327,7 +327,7 @@ TEST(Ttensor2, RotationStressRoundtrip)
 TEST(Ttensor2, RotationStrainRoundtrip)
 {
     mat::fixed<3,3> eps = {{0.01, 0.005, 0.003}, {0.005, 0.02, 0.004}, {0.003, 0.004, 0.03}};
-    tensor2 t(eps, VoigtType::strain);
+    tensor2 t(eps, Tensor2Type::strain);
 
     Rotation R = Rotation::from_euler(0.3, 0.5, 0.7, "zxz");
     tensor2 t_rot = t.rotate(R, true);
@@ -345,7 +345,7 @@ TEST(Ttensor2, PushPullBackStress)
 {
     // Push-forward then pull-back should be identity
     mat::fixed<3,3> sigma = {{100, 30, 20}, {30, 200, 40}, {20, 40, 300}};
-    tensor2 t(sigma, VoigtType::stress);
+    tensor2 t(sigma, Tensor2Type::stress);
 
     mat::fixed<3,3> F = {{1.1, 0.1, 0.05}, {0.02, 0.95, 0.03}, {0.01, 0.04, 1.05}};
 
@@ -358,7 +358,7 @@ TEST(Ttensor2, PushPullBackStress)
 TEST(Ttensor2, PushPullBackStrain)
 {
     mat::fixed<3,3> eps = {{0.01, 0.005, 0.003}, {0.005, 0.02, 0.004}, {0.003, 0.004, 0.03}};
-    tensor2 t(eps, VoigtType::strain);
+    tensor2 t(eps, Tensor2Type::strain);
 
     mat::fixed<3,3> F = {{1.1, 0.1, 0.05}, {0.02, 0.95, 0.03}, {0.01, 0.04, 1.05}};
 
@@ -441,10 +441,10 @@ TEST(Ttensor4, ContractStiffnessGivesStress)
 
     // Uniaxial strain eps_11 = 0.01
     vec::fixed<6> eps_v = {0.01, 0.0, 0.0, 0.0, 0.0, 0.0};
-    tensor2 eps = tensor2::from_voigt(eps_v, VoigtType::strain);
+    tensor2 eps = tensor2::from_voigt(eps_v, Tensor2Type::strain);
 
     tensor2 sigma = stiffness.contract(eps);
-    EXPECT_EQ(sigma.vtype(), VoigtType::stress);
+    EXPECT_EQ(sigma.vtype(), Tensor2Type::stress);
 
     // Cross-validate with raw matrix-vector product
     vec sig_ref = L * eps_v;
@@ -459,10 +459,10 @@ TEST(Ttensor4, ContractComplianceGivesStrain)
     tensor4 compliance(M, Tensor4Type::compliance);
 
     vec::fixed<6> sig_v = {100, 0, 0, 0, 0, 0};
-    tensor2 sig = tensor2::from_voigt(sig_v, VoigtType::stress);
+    tensor2 sig = tensor2::from_voigt(sig_v, Tensor2Type::stress);
 
     tensor2 eps = compliance.contract(sig);
-    EXPECT_EQ(eps.vtype(), VoigtType::strain);
+    EXPECT_EQ(eps.vtype(), Tensor2Type::strain);
 
     vec eps_ref = M * sig_v;
     EXPECT_LT(norm(vec(eps.voigt()) - eps_ref, 2), 1e-10);
@@ -741,7 +741,7 @@ TEST(Ttensor4, CoRateLogarithmicVariantsMatchSolverKernels)
 
     // Non-zero Kirchhoff stress so the B-correction actually contributes
     mat::fixed<3,3> tau_mat = {{120., 30., 10.}, {30., -50., 5.}, {10., 5., 80.}};
-    tensor2 tau(tau_mat, VoigtType::stress);
+    tensor2 tau(tau_mat, Tensor2Type::stress);
 
     tensor4 t_log   = stiff.push_forward(F, CoRate::logarithmic,   tau);
     tensor4 t_log_R = stiff.push_forward(F, CoRate::logarithmic_R, tau);
@@ -824,8 +824,8 @@ TEST(Ttensor4, Dyadic)
 {
     mat::fixed<3,3> a = {{1, 0, 0}, {0, 0, 0}, {0, 0, 0}};
     mat::fixed<3,3> b = {{0, 0, 0}, {0, 1, 0}, {0, 0, 0}};
-    tensor2 ta(a, VoigtType::stress);
-    tensor2 tb(b, VoigtType::stress);
+    tensor2 ta(a, Tensor2Type::stress);
+    tensor2 tb(b, Tensor2Type::stress);
 
     tensor4 d = dyadic(ta, tb);
     // a has Voigt [1,0,0,0,0,0], b has Voigt [0,1,0,0,0,0]
@@ -838,7 +838,7 @@ TEST(Ttensor4, Dyadic)
 TEST(Ttensor4, AutoDyadic)
 {
     mat::fixed<3,3> hydro = fill::eye;
-    tensor2 t(hydro, VoigtType::stress);
+    tensor2 t(hydro, Tensor2Type::stress);
 
     tensor4 ad = auto_dyadic(t);
     // Identity tensor has Voigt [1,1,1,0,0,0]
@@ -877,7 +877,7 @@ TEST(Ttensor_integration, StiffnessContractStrain)
 
     // A general strain state
     vec::fixed<6> eps_v = {0.01, -0.003, -0.003, 0.005, 0.002, 0.001};
-    tensor2 eps = tensor2::from_voigt(eps_v, VoigtType::strain);
+    tensor2 eps = tensor2::from_voigt(eps_v, Tensor2Type::strain);
 
     // Contract: sigma = L : epsilon
     tensor2 sigma = L.contract(eps);
@@ -885,7 +885,7 @@ TEST(Ttensor_integration, StiffnessContractStrain)
     // Verify against raw arma computation
     vec sig_ref = L_iso(E, nu, "Enu") * eps_v;
     EXPECT_LT(norm(vec(sigma.voigt()) - sig_ref, 2), 1e-10);
-    EXPECT_EQ(sigma.vtype(), VoigtType::stress);
+    EXPECT_EQ(sigma.vtype(), Tensor2Type::stress);
 }
 
 TEST(Ttensor_integration, ComplianceContractStress)
@@ -898,7 +898,7 @@ TEST(Ttensor_integration, ComplianceContractStress)
 
     // A general stress state
     vec::fixed<6> sig_v = {100, 50, 75, 30, 20, 10};
-    tensor2 sig = tensor2::from_voigt(sig_v, VoigtType::stress);
+    tensor2 sig = tensor2::from_voigt(sig_v, Tensor2Type::stress);
 
     // Contract: epsilon = M : sigma
     tensor2 eps = M.contract(sig);
@@ -906,7 +906,7 @@ TEST(Ttensor_integration, ComplianceContractStress)
     // Verify against raw arma computation
     vec eps_ref = M_iso(E, nu, "Enu") * sig_v;
     EXPECT_LT(norm(vec(eps.voigt()) - eps_ref, 2), 1e-10);
-    EXPECT_EQ(eps.vtype(), VoigtType::strain);
+    EXPECT_EQ(eps.vtype(), Tensor2Type::strain);
 }
 
 TEST(Ttensor_integration, FullCycle_Stress_Rotate_Contract)
@@ -917,7 +917,7 @@ TEST(Ttensor_integration, FullCycle_Stress_Rotate_Contract)
     // Build stiffness and strain
     tensor4 L(L_iso(E, nu, "Enu"), Tensor4Type::stiffness);
     vec::fixed<6> eps_v = {0.01, -0.003, -0.003, 0.005, 0.002, 0.001};
-    tensor2 eps = tensor2::from_voigt(eps_v, VoigtType::strain);
+    tensor2 eps = tensor2::from_voigt(eps_v, Tensor2Type::strain);
 
     // Compute stress in material frame
     tensor2 sigma = L.contract(eps);
@@ -959,15 +959,15 @@ TEST(Ttensor_batch, SizeMismatchThrows)
     R_match.each_slice() = mat::fixed<3,3>(fill::eye);
 
     // Matched and broadcast should succeed
-    EXPECT_NO_THROW(batch_rotate(v_stress, VoigtType::stress, R_match, true));
-    EXPECT_NO_THROW(batch_push_forward(v_stress, VoigtType::stress, F_match, false));
-    EXPECT_NO_THROW(batch_push_forward(v_stress, VoigtType::stress, F_bcast, false));
-    EXPECT_NO_THROW(batch_pull_back(v_stress, VoigtType::stress, F_match, false));
+    EXPECT_NO_THROW(batch_rotate(v_stress, Tensor2Type::stress, R_match, true));
+    EXPECT_NO_THROW(batch_push_forward(v_stress, Tensor2Type::stress, F_match, false));
+    EXPECT_NO_THROW(batch_push_forward(v_stress, Tensor2Type::stress, F_bcast, false));
+    EXPECT_NO_THROW(batch_pull_back(v_stress, Tensor2Type::stress, F_match, false));
 
     // Mismatched secondary must throw
-    EXPECT_THROW(batch_rotate(v_stress, VoigtType::stress, R_mismatch, true), std::invalid_argument);
-    EXPECT_THROW(batch_push_forward(v_stress, VoigtType::stress, F_mismatch, false), std::invalid_argument);
-    EXPECT_THROW(batch_pull_back(v_stress, VoigtType::stress, F_mismatch, false), std::invalid_argument);
+    EXPECT_THROW(batch_rotate(v_stress, Tensor2Type::stress, R_mismatch, true), std::invalid_argument);
+    EXPECT_THROW(batch_push_forward(v_stress, Tensor2Type::stress, F_mismatch, false), std::invalid_argument);
+    EXPECT_THROW(batch_pull_back(v_stress, Tensor2Type::stress, F_mismatch, false), std::invalid_argument);
 
     // tensor4 variants
     cube t4(6, 6, N, fill::randu);
@@ -989,10 +989,10 @@ TEST(Ttensor_batch, SizeMismatchThrows)
     cube t4_bcast(6, 6, 1);
     t4_bcast.slice(0) = mat::fixed<6,6>(fill::eye);
 
-    EXPECT_NO_THROW(batch_contract(t4_slice_eye, Tensor4Type::stiffness, t2_match, VoigtType::strain));
-    EXPECT_NO_THROW(batch_contract(t4_slice_eye, Tensor4Type::stiffness, t2_bcast, VoigtType::strain));
-    EXPECT_NO_THROW(batch_contract(t4_bcast, Tensor4Type::stiffness, t2_match, VoigtType::strain));
+    EXPECT_NO_THROW(batch_contract(t4_slice_eye, Tensor4Type::stiffness, t2_match, Tensor2Type::strain));
+    EXPECT_NO_THROW(batch_contract(t4_slice_eye, Tensor4Type::stiffness, t2_bcast, Tensor2Type::strain));
+    EXPECT_NO_THROW(batch_contract(t4_bcast, Tensor4Type::stiffness, t2_match, Tensor2Type::strain));
     // N4=N, N2=N_MISMATCH — both non-broadcast, sizes differ → must throw
-    EXPECT_THROW(batch_contract(t4_slice_eye, Tensor4Type::stiffness, t2_mismatch, VoigtType::strain),
+    EXPECT_THROW(batch_contract(t4_slice_eye, Tensor4Type::stiffness, t2_mismatch, Tensor2Type::strain),
                  std::invalid_argument);
 }

--- a/test/Libraries/Umat/Modular/Tmodular_umat.cpp
+++ b/test/Libraries/Umat/Modular/Tmodular_umat.cpp
@@ -137,12 +137,12 @@ TEST_F(InternalVariableTest, TensorViews) {
     InternalVariable EP("EP", EP_voigt, true);
 
     tensor2 EP_t = EP.as_strain();
-    EXPECT_EQ(EP_t.vtype(), VoigtType::strain);
+    EXPECT_EQ(EP_t.vtype(), Tensor2Type::strain);
     EXPECT_LT(arma::norm(arma::vec(EP_t.voigt()) - EP_voigt, 2), 1e-12);
 
     // Mutate via typed setter and read back
     arma::vec new_EP = {0.02, -0.01, -0.01, 0.004, 0.0, 0.0};
-    tensor2 new_EP_t = tensor2::from_voigt(new_EP, VoigtType::strain);
+    tensor2 new_EP_t = tensor2::from_voigt(new_EP, Tensor2Type::strain);
     EP.set_tensor2(new_EP_t);
     EXPECT_LT(arma::norm(EP.raw_voigt() - new_EP, 2), 1e-12);
 
@@ -158,8 +158,8 @@ TEST_F(InternalVariableTest, TensorViews) {
     // start-of-increment state with the variable's own vtype.
     EP.to_start();
     arma::vec newer_EP = {0.03, -0.015, -0.015, 0.006, 0.0, 0.0};
-    EP.set_tensor2(tensor2::from_voigt(newer_EP, VoigtType::strain));
-    EXPECT_EQ(EP.as_tensor2_start().vtype(), VoigtType::strain);
+    EP.set_tensor2(tensor2::from_voigt(newer_EP, Tensor2Type::strain));
+    EXPECT_EQ(EP.as_tensor2_start().vtype(), Tensor2Type::strain);
     EXPECT_LT(arma::norm(arma::vec(EP.as_tensor2_start().voigt()) - new_EP, 2), 1e-12);
     EXPECT_LT(arma::norm(arma::vec(EP.as_tensor2().voigt()) - newer_EP, 2), 1e-12);
     EXPECT_EQ(L_iv.as_tensor4_start().type(), Tensor4Type::stiffness);
@@ -199,7 +199,7 @@ TEST_F(InternalVariableTest, Matrix66TypedRotation) {
 // convention: assigning a stress-typed tensor2 to a strain-typed variable must
 // double the shear slots (not copy the raw components).
 TEST_F(InternalVariableTest, SetTensor2ReexpressesConvention) {
-    InternalVariable EP("EP", arma::zeros(6), true, VoigtType::strain);
+    InternalVariable EP("EP", arma::zeros(6), true, Tensor2Type::strain);
     // Stress-typed tensor with t12 = 3 -> voigt slot = 3 (no factor 2).
     tensor2 t = stress(arma::vec{1., 2., -3., 3., 0., 0.});
     EP.set_tensor2(t);
@@ -257,7 +257,7 @@ TEST(YieldCriterionTensor, VonMisesTensor2Match) {
                 1e-10);
 
     tensor2 lambda_t = yc.flow_direction(sigma_t);
-    EXPECT_EQ(lambda_t.vtype(), VoigtType::strain);
+    EXPECT_EQ(lambda_t.vtype(), Tensor2Type::strain);
     EXPECT_LT(arma::norm(arma::vec(lambda_t.voigt())
                          - yc.flow_direction(arma::vec(sigma_t.voigt())), 2),
               1e-10);
@@ -285,7 +285,7 @@ TEST(YieldCriterionTensor, VonMisesNearZeroStress) {
     EXPECT_NEAR(yc.equivalent_stress(sigma_t), 0.0, 1e-12);
 
     tensor2 lambda_t = yc.flow_direction(sigma_t);
-    EXPECT_EQ(lambda_t.vtype(), VoigtType::strain);
+    EXPECT_EQ(lambda_t.vtype(), Tensor2Type::strain);
     EXPECT_LT(arma::norm(arma::vec(lambda_t.voigt()), 2), 1e-10);
     // Raw path normalizes the noise instead (documented difference).
     EXPECT_NEAR(arma::norm(yc.flow_direction(arma::vec(sigma_t.voigt())), 2),
@@ -308,7 +308,7 @@ TEST(YieldCriterionTensor, DruckerTensor2Delegates) {
                 yc.equivalent_stress(arma::vec(sigma_t.voigt())),
                 1e-10);
     tensor2 lambda_t = yc.flow_direction(sigma_t);
-    EXPECT_EQ(lambda_t.vtype(), VoigtType::strain);
+    EXPECT_EQ(lambda_t.vtype(), Tensor2Type::strain);
     EXPECT_LT(arma::norm(arma::vec(lambda_t.voigt())
                          - yc.flow_direction(arma::vec(sigma_t.voigt())), 2),
               1e-10);
@@ -556,14 +556,14 @@ TEST_F(ElasticityModuleTest, TensorAccessors) {
 
     // Stiffness × compliance round-trip via typed contraction
     vec eps_voigt = {1e-3, -3e-4, -3e-4, 0.0, 0.0, 0.0};
-    tensor2 eps_t = tensor2::from_voigt(eps_voigt, VoigtType::strain);
+    tensor2 eps_t = tensor2::from_voigt(eps_voigt, Tensor2Type::strain);
     tensor2 sig_t = L_t.contract(eps_t);
-    EXPECT_EQ(sig_t.vtype(), VoigtType::stress);
+    EXPECT_EQ(sig_t.vtype(), Tensor2Type::stress);
     EXPECT_LT(norm(vec(sig_t.voigt()) - em.L() * eps_voigt, 2), 1e-8);
 
-    // alpha_tensor: VoigtType::strain (factor-2 on shear is irrelevant here, all shear=0)
+    // alpha_tensor: Tensor2Type::strain (factor-2 on shear is irrelevant here, all shear=0)
     tensor2 alpha_t = em.alpha_tensor();
-    EXPECT_EQ(alpha_t.vtype(), VoigtType::strain);
+    EXPECT_EQ(alpha_t.vtype(), Tensor2Type::strain);
     EXPECT_LT(norm(vec(alpha_t.voigt()) - em.alpha(), 2), 1e-12);
 
     // thermal_strain_tensor consistency
@@ -802,7 +802,7 @@ TEST_F(KinematicHardeningTest, PragerHardening) {
 
     // Check initial backstress is zero (stress-typed by signature)
     tensor2 X = hard->total_backstress(ivc_);
-    EXPECT_EQ(X.vtype(), VoigtType::stress);
+    EXPECT_EQ(X.vtype(), Tensor2Type::stress);
     EXPECT_DOUBLE_EQ(norm(vec(X.to_arma_voigt())), 0.0);
 
     // Hardening modulus should be (2/3)*C for Prager kinematic hardening
@@ -874,7 +874,7 @@ TEST_F(PlasticityMechanismTest, YieldAccessors) {
     EXPECT_NEAR(pm.equivalent_stress(sig_t), seq, 1e-10);
     EXPECT_NEAR(pm.yield_function(sig_t), Phi, 1e-10);
     tensor2 n_t = pm.flow_direction(sig_t);
-    EXPECT_EQ(n_t.vtype(), VoigtType::strain);
+    EXPECT_EQ(n_t.vtype(), Tensor2Type::strain);
     EXPECT_LT(norm(vec(n_t.voigt()) - n, 2), 1e-10);
 
     // Uniaxial stress above yield: sigma_11 = 400 > sigma_Y => Phi > 0.


### PR DESCRIPTION
Replace the 2nd-order tensor tag VoigtType with a clearer Tensor2Type across the codebase and Python bindings. Added a deprecated VoigtType alias in tensor.hpp and exposed it in the Python module for backward compatibility. Updated all C++ headers/sources and pybind wrapper code to use Tensor2Type (function signatures, error messages, factories, batch operations, and inference helpers), and adjusted the Python mapping/exports accordingly. Minor example update: IsotropicElasticity now passes convention="Enu" to clarify C1/C2 semantics. This change is primarily a rename/refactor to improve naming clarity while keeping a compatibility alias for external users.