### PR TITLE
Use absolute sccache and Ninja; add modular docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,8 +65,11 @@ jobs:
           # scikit-build-core honors CMAKE_ARGS; the compiler-launcher property
           # only works with the Ninja generator (ignored by Visual Studio), so
           # the MSVC dev env + ninja (installed below) are required for sccache.
+          $sc = $env:SCCACHE_PATH -replace '\\','/'
           "SCCACHE_GHA_ENABLED=true" | Out-File $env:GITHUB_ENV -Append
-          "CMAKE_ARGS=-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache" | Out-File $env:GITHUB_ENV -Append
+          "SCCACHE_IDLE_TIMEOUT=0" | Out-File $env:GITHUB_ENV -Append
+          "CMAKE_ARGS=-DCMAKE_C_COMPILER_LAUNCHER=$sc -DCMAKE_CXX_COMPILER_LAUNCHER=$sc" | Out-File $env:GITHUB_ENV -Append
+          "CMAKE_GENERATOR=Ninja" | Out-File $env:GITHUB_ENV -Append
 
       - name: Editable install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,17 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           pip install ninja
+          # Absolute launcher path (forward slashes for CMake): the sccache
+          # action exports SCCACHE_PATH but does NOT put sccache on PATH, and
+          # msvc-dev-cmd rewrites PATH anyway. Idle timeout 0 keeps the server
+          # (and its stats) alive across the whole job.
+          $sc = $env:SCCACHE_PATH -replace '\\','/'
           "SCCACHE_GHA_ENABLED=true" | Out-File $env:GITHUB_ENV -Append
-          "CMAKE_ARGS=-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache" | Out-File $env:GITHUB_ENV -Append
+          "SCCACHE_IDLE_TIMEOUT=0" | Out-File $env:GITHUB_ENV -Append
+          "CMAKE_ARGS=-DCMAKE_C_COMPILER_LAUNCHER=$sc -DCMAKE_CXX_COMPILER_LAUNCHER=$sc" | Out-File $env:GITHUB_ENV -Append
+          # scikit-build-core only picks Ninja over Visual Studio when ninja is
+          # importable/visible to the python actually running the build
+          "CMAKE_GENERATOR=Ninja" | Out-File $env:GITHUB_ENV -Append
 
       - name: Prepare conda environment (Unix)
         if: runner.os != 'Windows'
@@ -88,11 +97,12 @@ jobs:
         run: |
           cmake -S . -B build -G Ninja `
               -DCMAKE_BUILD_TYPE=Release `
-              -DCMAKE_C_COMPILER_LAUNCHER=sccache `
-              -DCMAKE_CXX_COMPILER_LAUNCHER=sccache `
+              -DCMAKE_C_COMPILER_LAUNCHER="$env:SCCACHE_PATH" `
+              -DCMAKE_CXX_COMPILER_LAUNCHER="$env:SCCACHE_PATH" `
               -DCMAKE_INSTALL_PREFIX="$env:CONDA_PREFIX/Library" `
               -Wno-dev
           cmake --build build
+          & $env:SCCACHE_PATH --show-stats
 
       - name: Tests (Unix)
         if: runner.os != 'Windows'
@@ -119,8 +129,9 @@ jobs:
       - name: Install simcoon Python bindings (Windows)
         if: runner.os == 'Windows'
         run: |
-          pip install scikit-build-core pybind11 numpy
+          pip install scikit-build-core pybind11 numpy ninja
           pip install . --no-build-isolation
+          & $env:SCCACHE_PATH --show-stats
 
       - name: Smoke test simcoon Python (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Install simcoon Python bindings (Windows)
         if: runner.os == 'Windows'
         run: |
-          pip install scikit-build-core pybind11 numpy ninja
+          pip install scikit-build-core pybind11 numpy
           pip install . --no-build-isolation
           & $env:SCCACHE_PATH --show-stats
 

--- a/docs/simulation/index.rst
+++ b/docs/simulation/index.rst
@@ -8,6 +8,7 @@ Simulation
    solver.rst
    python_solver.rst
    umat_catalog.rst
+   modular_python.rst
    umat_tutorial.rst
    identification.rst
    output.rst

--- a/docs/simulation/modular_python.rst
+++ b/docs/simulation/modular_python.rst
@@ -1,0 +1,219 @@
+==========================================
+Building materials in Python (``modular``)
+==========================================
+
+.. module:: simcoon.modular
+
+The :mod:`simcoon.modular` package is the Python builder for the composable
+``MODUL`` engine: a constitutive model is assembled from an **elasticity**
+definition plus any combination of **mechanisms** (plasticity,
+viscoelasticity, damage), and serialized into the self-describing props
+stream that the C++ engine consumes. The same object drives the in-memory
+solver, the file solver, or any FEA coupling — see the
+:doc:`UMAT catalog <umat_catalog>` for how ``MODUL`` fits among the other
+material names. Units are MPa; Voigt order is [11, 22, 33, 12, 13, 23].
+
+Quick start
+-----------
+
+.. code-block:: python
+
+    from simcoon.modular import (
+        ModularMaterial, IsotropicElasticity,
+        Plasticity, VonMisesYield, VoceHardening, ArmstrongFrederickHardening,
+    )
+    from simcoon import solver
+
+    mat = ModularMaterial(
+        elasticity=IsotropicElasticity(C1=210000.0, C2=0.3, alpha=1.2e-5,
+                                       convention="Enu"),
+        mechanisms=[
+            Plasticity(
+                sigma_Y=300.0,
+                yield_criterion=VonMisesYield(),
+                isotropic_hardening=VoceHardening(Q=200.0, b=10.0),
+                kinematic_hardening=ArmstrongFrederickHardening(C=20000.0, D=100.0),
+            ),
+        ],
+    )
+    print(mat.summary())
+
+    step = solver.StepMeca(control=['strain'] + ['stress'] * 5,
+                           value=[0.02, 0, 0, 0, 0, 0], ninc=100)
+    res = solver.solve(step, "MODUL", mat.props, mat.nstatev)
+
+``mat.props`` and ``mat.nstatev`` are all any caller needs — they work
+identically with ``material.dat`` files, :func:`simcoon.umat` point
+evaluation, micromechanics phase files (``Nellipsoids``/``Nlayers``) and FEA
+couplings such as fedoo.
+
+Elasticity
+----------
+
+Exactly one elasticity definition per material. The elastic constants are
+**ordinal slots** ``C1..Cn`` whose meaning is fixed by the ``convention``
+argument (enum, int, or string aliases):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 34 40
+
+   * - Class
+     - Parameters
+     - Conventions (string aliases)
+   * - :class:`IsotropicElasticity`
+     - ``C1, C2, alpha``
+     - ``"Enu"`` (C1=E, C2=nu, default), ``"nuE"``, ``"Kmu"``/``"KG"``,
+       ``"muK"``, ``"lambdamu"``, ``"mulambda"``
+   * - :class:`CubicElasticity`
+     - ``C1, C2, C3, alpha``
+     - ``"EnuG"`` (default), ``"Cii"`` (C11, C12, C44)
+   * - :class:`TransverseIsotropicElasticity`
+     - ``EL, ET, nuTL, nuTT, GLT, alpha_L, alpha_T, axis``
+     - ``"EnuG"`` only (axis = isotropy axis, default 3)
+   * - :class:`OrthotropicElasticity`
+     - ``C1..C9, alpha1..alpha3``
+     - ``"EnuG"`` (E1,E2,E3,nu12,nu13,nu23,G12,G13,G23; default), ``"Cii"``
+
+``alpha`` are the thermal-expansion coefficients (per direction where
+applicable).
+
+Yield criteria
+--------------
+
+Used inside :class:`Plasticity`; the criterion defines the equivalent stress
+:math:`\sigma_{eq}` of the yield function
+:math:`f = \sigma_{eq}(\boldsymbol{\sigma} - \mathbf{X}) - (\sigma_Y + R(p))`:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 30 42
+
+   * - Class
+     - Parameters
+     - Criterion
+   * - :class:`VonMisesYield`
+     - —
+     - :math:`\sqrt{\tfrac{3}{2}\,\mathbf{s}:\mathbf{s}}`
+   * - :class:`TrescaYield`
+     - —
+     - Maximum shear stress
+   * - :class:`DruckerYield`
+     - ``b, n``
+     - Drucker :math:`J_2`–:math:`J_3` criterion
+   * - :class:`HillYield`
+     - ``F, G, H, L, M, N``
+     - Hill 1948 quadratic anisotropy
+   * - :class:`DFAYield`
+     - ``F, G, H, L, M, N, K``
+     - Deshpande–Fleck–Ashby (pressure-sensitive)
+   * - :class:`AnisotropicYield`
+     - ``P11, P22, P33, P12, P13, P23, P44, P55, P66``
+     - Full quadratic form. **P must be an admissible (convex) form**:
+       symmetric with zero row sums on the normal block — an indefinite P
+       produces ``sqrt(<0) = NaN``.
+
+Isotropic hardening
+-------------------
+
+The isotropic hardening law :math:`R(p)` of the accumulated plastic strain
+:math:`p`:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 24 46
+
+   * - Class
+     - Parameters
+     - Law
+   * - :class:`NoIsotropicHardening`
+     - —
+     - :math:`R = 0` (perfect plasticity, default)
+   * - :class:`LinearIsotropicHardening`
+     - ``H``
+     - :math:`R = H\,p`
+   * - :class:`PowerLawHardening`
+     - ``k, m``
+     - :math:`R = k\,p^m` — for :math:`m < 1` the singular onset slope is
+       C\ :sup:`1`-regularized below :math:`p = 10^{-6}` (exact above)
+   * - :class:`VoceHardening`
+     - ``Q, b``
+     - :math:`R = Q\,(1 - e^{-b\,p})`
+   * - :class:`CombinedVoceHardening`
+     - ``terms = ((Q_1, b_1), ...)``
+     - :math:`R = \sum_i Q_i\,(1 - e^{-b_i p})` (standard independent sum —
+       note this differs from the removed legacy EPCHG coupling, see the
+       :doc:`catalog <umat_catalog>`)
+
+Kinematic hardening
+-------------------
+
+The back stress :math:`\mathbf{X}` shifting the yield surface. The stored
+internal variable is the **back-strain** :math:`\boldsymbol{\alpha}`
+(thermodynamic variable); :math:`\mathbf{X} = \tfrac{2}{3} C \boldsymbol{\alpha}`:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 26 42
+
+   * - Class
+     - Parameters
+     - Law
+   * - :class:`NoKinematicHardening`
+     - —
+     - :math:`\mathbf{X} = 0` (default)
+   * - :class:`PragerHardening`
+     - ``C``
+     - Linear: :math:`\dot{\boldsymbol{\alpha}} = \dot{p}\,\mathbf{n}`
+   * - :class:`ArmstrongFrederickHardening`
+     - ``C, D``
+     - :math:`\dot{\mathbf{X}} = \tfrac{2}{3}C\,\dot{\boldsymbol{\varepsilon}}^p - D\,\mathbf{X}\dot{p}`
+   * - :class:`ChabocheHardening`
+     - ``terms = ((C_1, D_1), ...)``
+     - :math:`\mathbf{X} = \sum_i \mathbf{X}_i`, each branch
+       Armstrong–Frederick
+
+Mechanisms
+----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 40 34
+
+   * - Class
+     - Parameters
+     - Physics
+   * - :class:`Plasticity`
+     - ``sigma_Y, yield_criterion, isotropic_hardening, kinematic_hardening``
+     - Rate-independent plasticity (Fischer–Burmeister return mapping)
+   * - :class:`Viscoelasticity`
+     - ``terms = ((E_i, nu_i, etaB_i, etaS_i), ...)``
+     - Generalized Maxwell (Prony) branches: per branch a spring
+       (:math:`E_i, \nu_i`) in series with bulk/shear dashpots
+       (:math:`\eta_B, \eta_S`) — same rheology and layout as the kept
+       ``PRONK`` kernel
+   * - :class:`Damage`
+     - ``Y_0, Y_c, damage_type, A, n``
+     - Scalar stiffness-degradation damage; ``damage_type`` selects the
+       evolution law: ``LINEAR``, ``EXPONENTIAL``, ``POWER_LAW`` (uses
+       ``A, n``) or ``WEIBULL``
+
+Multiple mechanisms compose additively on the inelastic strain; the
+registration order defines the statev layout (see the
+:doc:`catalog <umat_catalog>` statev section).
+
+Tangent operator and finite strain
+----------------------------------
+
+``MODUL`` honors the solver's ``tangent_mode`` (continuum or algorithmic,
+algorithmic being the 2.0 default — :doc:`solver`). Under the finite-strain
+control types the composition acts as a Hencky hyperelastic law on the
+logarithmic strain and requires ``corate_type = 3`` (log_R).
+
+See also
+--------
+
+- :doc:`umat_catalog` — where ``MODUL`` and the adapter-served legacy names
+  meet, props streams and statev layouts
+- :doc:`umat_tutorial` — writing a dedicated UMAT by hand instead
+- ``examples/mechanical/MODUL.py`` — runnable gallery example

--- a/docs/simulation/modular_python.rst
+++ b/docs/simulation/modular_python.rst
@@ -109,9 +109,8 @@ Used inside :class:`Plasticity`; the criterion defines the equivalent stress
      - Deshpande–Fleck–Ashby (pressure-sensitive)
    * - :class:`AnisotropicYield`
      - ``P11, P22, P33, P12, P13, P23, P44, P55, P66``
-     - Full quadratic form. **P must be an admissible (convex) form**:
-       symmetric with zero row sums on the normal block — an indefinite P
-       produces ``sqrt(<0) = NaN``.
+     - Full quadratic form; P admissibility requirements: see the ``EPANI``
+       row of the :doc:`catalog <umat_catalog>`.
 
 Isotropic hardening
 -------------------
@@ -195,8 +194,9 @@ Mechanisms
    * - :class:`Damage`
      - ``Y_0, Y_c, damage_type, A, n``
      - Scalar stiffness-degradation damage; ``damage_type`` selects the
-       evolution law: ``LINEAR``, ``EXPONENTIAL``, ``POWER_LAW`` (uses
-       ``A, n``) or ``WEIBULL``
+       evolution law and its extra parameters: ``LINEAR`` (none),
+       ``EXPONENTIAL`` (``A``), ``POWER_LAW`` (``n``) or ``WEIBULL``
+       (``A, n``)
 
 Multiple mechanisms compose additively on the inelastic strain; the
 registration order defines the statev layout (see the
@@ -208,7 +208,9 @@ Tangent operator and finite strain
 ``MODUL`` honors the solver's ``tangent_mode`` (continuum or algorithmic,
 algorithmic being the 2.0 default — :doc:`solver`). Under the finite-strain
 control types the composition acts as a Hencky hyperelastic law on the
-logarithmic strain and requires ``corate_type = 3`` (log_R).
+logarithmic strain and requires ``corate_type = 3`` (log_R): pass
+``corate="logarithmic_R"`` to :func:`simcoon.solver.solve` — the default
+``corate="logarithmic"`` is the XBM rate (code 2).
 
 See also
 --------

--- a/examples/data/THERM_SMAUT_path_1.txt
+++ b/examples/data/THERM_SMAUT_path_1.txt
@@ -1,5 +1,5 @@
 #Initial_temperature
-293.15
+323.15
 #Number_of_blocks
 1
 

--- a/examples/data/THERM_SMAUT_path_10.txt
+++ b/examples/data/THERM_SMAUT_path_10.txt
@@ -1,5 +1,5 @@
 #Initial_temperature
-293.15
+323.15
 #Number_of_blocks
 1
 

--- a/examples/data/THERM_SMAUT_path_100.txt
+++ b/examples/data/THERM_SMAUT_path_100.txt
@@ -1,5 +1,5 @@
 #Initial_temperature
-293.15
+323.15
 #Number_of_blocks
 1
 

--- a/examples/data/THERM_SMAUT_path_1000.txt
+++ b/examples/data/THERM_SMAUT_path_1000.txt
@@ -1,5 +1,5 @@
 #Initial_temperature
-293.15
+323.15
 #Number_of_blocks
 1
 

--- a/include/simcoon/Continuum_mechanics/Umat/Modular/damage_mechanism.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/damage_mechanism.hpp
@@ -134,6 +134,12 @@ public:
     /// tangent_contribution.
     [[nodiscard]] double stiffness_reduction() const override;
 
+    /// Explicitly integrated, energy-release-typed row — excluded from the
+    /// drift-guard ARMING count (see StrainMechanism::guarded_constraints);
+    /// the commit checks themselves are no-ops here through the default
+    /// multiplier_cap()/state_drift().
+    [[nodiscard]] bool guarded_constraints() const override { return false; }
+
     /// Both dPhi/dsigma and kappa are M·σ products here, i.e. STRAIN-typed —
     /// unlike the stress-typed kappa of plasticity/viscoelasticity. The
     /// orchestrator's engineering-Voigt dot therefore mixes conventions for

--- a/include/simcoon/Continuum_mechanics/Umat/Modular/modular_umat.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/modular_umat.hpp
@@ -96,6 +96,14 @@ private:
     int maxiter_;           ///< Maximum iterations for return mapping
     double precision_;      ///< Convergence tolerance
 
+    /// Composition invariant cached by initialize(): the flow-rule drift
+    /// guard of run() is armed only when at least TWO guarded constraint
+    /// ROWS are present (across one or several mechanisms) — the
+    /// multi-surface configuration where the FB tug-of-war pathology lives.
+    /// A single guarded row keeps the unguarded legacy-CCP commit semantics
+    /// and commits identically to its reference kernel.
+    bool drift_guard_armed_{false};
+
 public:
     /**
      * @brief Default constructor
@@ -316,8 +324,23 @@ private:
      * 1. Computes elastic prediction (trial stress)
      * 2. Evaluates constraint functions (Phi) from all mechanisms
      * 3. Solves for multiplier increments via Fischer-Burmeister
-     * 4. Updates internal variables and recomputes stress
+     * 4. Updates internal variables (incremental CCP update) and recomputes
+     *    the stress
      * 5. Repeats until convergence (error < precision_)
+     *
+     * The per-iteration incremental update (step 4) is kept deliberately
+     * over a total-multiplier backward-Euler refresh inside the loop: the
+     * refresh at a lagged stress is non-contractive for curved criteria at
+     * large increments (\f$ \Delta s\,\mathbf{n}:\mathbf{L}:\mathbf{n} /
+     * \sigma_Y > 1 \f$ — traced as a period-2 limit cycle on DFA and
+     * divergence on Hill power-law where CCP converges); making it robust
+     * means solving state and stress simultaneously, i.e. the closest-point
+     * return map (reserved tangent_closest_point mode, future release).
+     *
+     * By the reference CCP convention a finite unconverged-at-maxiter state
+     * is still committed (the damage row in particular is integrated
+     * explicitly and never drives the FB error to precision_); run() rejects
+     * only unusable states with a step cut (see its reject block).
      *
      * @param Etot Total strain at start of increment
      * @param DEtot Strain increment

--- a/include/simcoon/Continuum_mechanics/Umat/Modular/plasticity_mechanism.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/plasticity_mechanism.hpp
@@ -206,6 +206,27 @@ public:
         const arma::vec& Ds_total,
         int offset) override;
 
+    /// Flow-rule residual of the committed state (tensorial strain norms,
+    /// flow direction at the end stress shifted by the backstress); see
+    /// StrainMechanism::state_drift.
+    [[nodiscard]] double state_drift(const arma::vec& sigma) const override;
+
+    /// Base default when the criterion's flow direction is stable within an
+    /// increment, infinity (opt-out) otherwise — the classification lives on
+    /// YieldCriterion::has_stable_flow_direction.
+    [[nodiscard]] double drift_tolerance() const override;
+
+    /// 1.0 = 100% plastic strain in a single increment: the accumulated
+    /// plastic multiplier is strain-scale, and the first FB runaway
+    /// excursion (traced: 0.83 -> 433 -> 4e13) must be caught before it
+    /// saturates the hardening state, whose garbage tangent would reseed
+    /// the divergence on every solver retry.
+    [[nodiscard]] double multiplier_cap() const override;
+
+    /// Committed Dp = p - p_start from the internal variable (projected by
+    /// update(); see StrainMechanism::committed_multiplier).
+    [[nodiscard]] double committed_multiplier() const override;
+
     arma::vec inelastic_strain() const override;
 
     void update(

--- a/include/simcoon/Continuum_mechanics/Umat/Modular/strain_mechanism.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/strain_mechanism.hpp
@@ -43,6 +43,7 @@ along with simcoon.  If not, see <http://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 #include <map>
+#include <limits>
 #include <armadillo>
 #include <simcoon/Continuum_mechanics/Functions/tensor.hpp>
 #include <simcoon/Continuum_mechanics/Umat/Modular/internal_variable_collection.hpp>
@@ -315,6 +316,92 @@ public:
         (void)Ds_total;
         (void)offset;
         return false;
+    }
+
+    /**
+     * @brief Whether this mechanism carries constraint rows that can enter
+     * the multi-surface tug-of-war the orchestrator's drift guard watches
+     * for (arming rule: see ModularUMAT::drift_guard_armed_).
+     *
+     * Default true, so any future yield-like mechanism (threshold
+     * viscoplasticity, martensitic transformation) participates without
+     * touching the orchestrator; opting-out overrides carry their own
+     * rationale.
+     */
+    [[nodiscard]] virtual bool guarded_constraints() const {
+        return true;
+    }
+
+    /**
+     * @brief Per-increment cap on this mechanism's multiplier rows at
+     * commit; a committed multiplier above it is rejected with a step cut.
+     *
+     * Default infinity (no cap): only the mechanism knows its multiplier's
+     * scale and what a runaway magnitude means for it — mechanisms with
+     * strain-scale multipliers override (see PlasticityMechanism).
+     */
+    [[nodiscard]] virtual double multiplier_cap() const {
+        return std::numeric_limits<double>::infinity();
+    }
+
+    /**
+     * @brief Largest COMMITTED multiplier increment across this mechanism's
+     * rows, compared against multiplier_cap() by the orchestrator.
+     *
+     * Read from the internal-variable state, NOT from the raw
+     * Fischer-Burmeister row: the per-iteration state update may project
+     * (clamp) its steps without writing back into the row, so after a
+     * clipped excursion the committed increment can exceed the raw row —
+     * exactly the oscillating regime the cap targets. Default 0 (mechanisms
+     * without a capped multiplier never trip).
+     */
+    [[nodiscard]] virtual double committed_multiplier() const {
+        return 0.0;
+    }
+
+    /**
+     * @brief Largest state_drift() value the orchestrator accepts at commit
+     * for this mechanism's rows; above it the increment is rejected with a
+     * step cut.
+     *
+     * Default 0.5, calibrated on the quadratic deviatoric criteria: healthy
+     * CCP returns measure ~1e-2 (in-increment flow rotation) while the
+     * pathological oscillating-FB commits measured 1.5-7.6 (two von Mises
+     * mechanisms, large reload, stress committed hundreds of MPa wrong).
+     * A mechanism whose flow legitimately rotates O(1) within an increment
+     * (strongly curved or non-smooth criteria) returns infinity — the drift
+     * measure is not discriminating there and the row keeps the legacy-CCP
+     * commit semantics.
+     */
+    [[nodiscard]] virtual double drift_tolerance() const {
+        return 0.5;
+    }
+
+    /**
+     * @brief Relative inconsistency of the committed state with respect to
+     * its converged multipliers, checked by the orchestrator before commit.
+     *
+     * The CCP loop accumulates the state along the Fischer-Burmeister
+     * iteration path (\f$ \Delta\mathbf{V} = \sum_k ds_k\,\boldsymbol{\Lambda}_k \f$).
+     * For a healthy return this telescopes to the flow rule
+     * \f$ \Delta\mathbf{V} \approx \Delta s\,\boldsymbol{\Lambda}(\sigma_{end}) \f$;
+     * when the FB Newton oscillates, the accumulated state drifts away from
+     * it while still satisfying \f$ \Phi = 0 \f$ — a spurious root the
+     * orchestrator rejects with a step cut (arming policy: see
+     * ModularUMAT::run). The measure must vanish with the increment size so
+     * that solver step cuts terminate.
+     *
+     * @return the relative drift measure (0 = perfectly consistent).
+     * Default 0. Guarded mechanisms should override with their flow-rule
+     * residual,
+     * \f$ \|\Delta\mathbf{V} - \Delta s\,\boldsymbol{\Lambda}_{end}\| /
+     * (\Delta s\,\|\boldsymbol{\Lambda}_{end}\|) \f$
+     * with a REGULARIZED (floored) denominator so the measure stays finite
+     * and vanishing as \f$ \Delta s \to 0 \f$ — see PlasticityMechanism.
+     */
+    [[nodiscard]] virtual double state_drift(const arma::vec& sigma) const {
+        (void)sigma;
+        return 0.0;
     }
 
     /**

--- a/include/simcoon/Continuum_mechanics/Umat/Modular/viscoelastic_mechanism.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/viscoelastic_mechanism.hpp
@@ -86,6 +86,12 @@ public:
     [[nodiscard]] int num_constraints() const override { return N_prony_; }
     [[nodiscard]] MechanismType type() const override { return MechanismType::VISCOELASTICITY; }
 
+    /// Strain-form rate rows, stress-decoupled — excluded from the
+    /// drift-guard ARMING count (see StrainMechanism::guarded_constraints);
+    /// the commit checks themselves are no-ops here through the default
+    /// multiplier_cap()/state_drift().
+    [[nodiscard]] bool guarded_constraints() const override { return false; }
+
     void compute_constraints(
         const arma::vec& sigma,
         const arma::vec& E_total,

--- a/include/simcoon/Continuum_mechanics/Umat/Modular/yield_criterion.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/yield_criterion.hpp
@@ -187,6 +187,21 @@ public:
     [[nodiscard]] bool has_flow_hessian() const noexcept;
 
     /**
+     * @brief Whether the flow direction stays nearly constant over one
+     * return-mapping increment.
+     *
+     * True for the quadratic deviatoric family (von Mises, Hill, generic
+     * anisotropic): the flow rotation within a return is bounded by the
+     * increment size. False for pressure-sensitive surfaces (Drucker, DFA —
+     * the volumetric flow component varies strongly along the return) and
+     * vertex criteria (Tresca — the flow jumps between facets), whose flow
+     * legitimately rotates O(1) within a single large increment. Consumed
+     * by PlasticityMechanism::drift_tolerance to decide whether the
+     * commit-time flow-rule drift measure is discriminating.
+     */
+    [[nodiscard]] bool has_stable_flow_direction() const noexcept;
+
+    /**
      * @brief Analytic flow Hessian $ \mathrm{d}oldsymbol{\Lambda}/
      * \mathrm{d}oldsymbol{\sigma} = \partial^2\sigma_{eq}/\partial
      * oldsymbol{\sigma}^2 $ (6x6, compliance-like Voigt).

--- a/src/Continuum_mechanics/Umat/Modular/modular_umat.cpp
+++ b/src/Continuum_mechanics/Umat/Modular/modular_umat.cpp
@@ -36,12 +36,6 @@ along with simcoon.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace simcoon {
 
-namespace {
-// Per-increment plastic-multiplier runaway cap for the committed-state guard
-// in ModularUMAT::run (see the reject block there for the rationale).
-constexpr double Ds_cap_plastic = 1.0;
-}  // namespace
-
 // ========== Constructor ==========
 
 ModularUMAT::ModularUMAT()
@@ -194,16 +188,23 @@ void ModularUMAT::initialize(int nstatev, arma::vec& statev) {
         mech->unpack(statev);
     }
 
-    // Cache per-mechanism constraint-row offsets (constant for the rest of
-    // the object's lifetime).
+    // Cache the composition invariants (constant for the rest of the
+    // object's lifetime): per-mechanism constraint-row offsets and the
+    // drift-guard arming decision (see the member doc).
     mech_offset_.assign(mechanisms_.size(), 0);
-    {
-        int acc = 0;
-        for (size_t m = 0; m < mechanisms_.size(); ++m) {
-            mech_offset_[m] = acc;
-            acc += mechanisms_[m]->num_constraints();
+    int acc = 0;
+    int n_guarded_rows = 0;
+    for (size_t m = 0; m < mechanisms_.size(); ++m) {
+        mech_offset_[m] = acc;
+        acc += mechanisms_[m]->num_constraints();
+        if (mechanisms_[m]->guarded_constraints()) {
+            // Count ROWS, not mechanisms: a single future mechanism carrying
+            // several coupled surfaces (SMA forward/reverse transformation)
+            // is already the multi-surface configuration the guard watches.
+            n_guarded_rows += mechanisms_[m]->num_constraints();
         }
     }
+    drift_guard_armed_ = (n_guarded_rows >= 2);
 
     initialized_ = true;
 }
@@ -318,40 +319,41 @@ void ModularUMAT::run(
         n_total += mech->num_constraints();
     }
 
-    // Perform return mapping. return_mapping reports FB convergence, but by the
-    // reference CCP convention a finite unconverged-at-maxiter state is still
-    // committed (the damage row in particular is integrated explicitly and
-    // never drives the FB error to precision_). Only a NON-FINITE result
-    // (true divergence -> NaN/Inf) is unusable and triggers a step cut.
+    // Perform return mapping (unconverged-at-maxiter commit semantics: see
+    // the return_mapping doc).
     arma::vec Ds_total = arma::zeros(n_total);
     return_mapping(Etot, DEtot, sigma, T_init_, T, DT, DTime, ndi, Ds_total);
 
-    // Reject unusable committed states with a step cut: (a) non-finite stress
-    // (true divergence); (b) a pathological PLASTIC multiplier beyond
-    // Ds_cap_plastic — the first FB runaway excursion (traced: 0.83 -> 433 ->
-    // 4e13) must be caught before it saturates the hardening state, whose
-    // garbage tangent would reseed the divergence on every solver retry.
+    // Reject unusable committed states with a step cut: non-finite stress
+    // (true divergence), a runaway COMMITTED multiplier (multiplier_cap —
+    // checked on the state, not the raw FB row, which can be smaller after
+    // clipped excursions), or a state that drifted from the flow rule
+    // (state_drift) — a spurious CONVERGED root of an oscillating FB Newton,
+    // invisible to every residual check (arming policy: see
+    // drift_guard_armed_). Thresholds are per-mechanism, infinity = opt out.
     // (Negative multipliers are handled at the source: PlasticityMechanism
-    // projects the FB update onto p >= p_start, and PowerLawHardening is
+    // projects the state update onto p >= p_start, and PowerLawHardening is
     // C1-regularized at onset, so no negative-Ds check is needed here.)
-    // Plasticity rows only: damage rows are energy-release-typed
-    // (Phi = Y - Y_max, MPa scale) and legitimately exceed this bound.
     bool reject = !sigma.is_finite();
     for (size_t m = 0; !reject && m < mechanisms_.size(); ++m) {
-        if (mechanisms_[m]->type() != MechanismType::PLASTICITY) continue;
-        const int n = mechanisms_[m]->num_constraints();
-        if (n == 0) continue;
-        const auto Ds_m = Ds_total.subvec(mech_offset_[m],
-                                          mech_offset_[m] + n - 1);
-        reject = (Ds_m.max() > Ds_cap_plastic);
+        const double drift_tol = mechanisms_[m]->drift_tolerance();
+        reject = (mechanisms_[m]->committed_multiplier() >
+                      mechanisms_[m]->multiplier_cap())
+              || (drift_guard_armed_ && std::isfinite(drift_tol) &&
+                  mechanisms_[m]->state_drift(sigma) > drift_tol);
     }
     if (reject) {
         // Ask the global solver to halve the increment and retry. statev is
         // left at its incoming values (pack_all is skipped) so the retry
-        // restarts from the correct state; Lt is set elastic to keep the
-        // rejected-step output well-defined.
+        // restarts from the correct state; sigma is reset to its incoming
+        // value and Lt to elastic so the rejected-step output stays a
+        // self-consistent triple — the solver's inforce-at-Dn_mini branch
+        // commits this output WITHOUT re-running the UMAT, and a rejected
+        // stress paired with the un-updated statev would silently corrupt
+        // the rest of the history.
+        sigma = sigma_start_;
         tnew_dt = 0.5;
-        Lt = elasticity_.L();
+        Lt = stiffness_reduction() * elasticity_.L();
         return;
     }
 
@@ -454,6 +456,8 @@ void ModularUMAT::return_mapping(
         // Solve using Fischer-Burmeister
         Fischer_Burmeister_m(Phi, Y_crit, B, Ds_total, ds, error);
 
+        // Incremental CCP update (see the header for why this is not a
+        // total-multiplier refresh)
         for (size_t m = 0; m < mechanisms_.size(); ++m) {
             mechanisms_[m]->update(ds, mech_offset_[m]);
         }

--- a/src/Continuum_mechanics/Umat/Modular/plasticity_mechanism.cpp
+++ b/src/Continuum_mechanics/Umat/Modular/plasticity_mechanism.cpp
@@ -23,9 +23,20 @@ along with simcoon.  If not, see <http://www.gnu.org/licenses/>.
 #include <simcoon/Continuum_mechanics/Umat/Modular/plasticity_mechanism.hpp>
 #include <simcoon/Continuum_mechanics/Functions/contimech.hpp>
 #include <simcoon/parameter.hpp>
+#include <algorithm>
+#include <limits>
 #include <stdexcept>
 
 namespace simcoon {
+
+namespace {
+// Absolute strain floor of the state_drift denominator (see state_drift).
+// 1e-4: at near-zero committed Dp, rejection then requires a flow-rule
+// error above tolerance * floor = 5e-5 strain (~10 MPa) — two orders below
+// the measured pathology (~1e-2) and comfortably above the EP residue a
+// benign overshoot/walk-back leaves behind (~1e-5).
+constexpr double drift_scale_floor = 1.0e-4;
+}  // namespace
 
 // ========== Constructor ==========
 
@@ -202,7 +213,13 @@ bool PlasticityMechanism::refresh_state(
     const arma::vec& sigma,
     const arma::vec& Ds_total,
     int offset) {
-    const double dp = Ds_total(offset);
+    // dp >= 0: one-shot projection of the TOTAL row (the CPP contract
+    // re-derives the state from Ds_total). NOTE this is not identical to
+    // update()'s incremental clamping — after a clipped mid-iteration
+    // excursion the two commit different p from the same row history; the
+    // future closest-point integrator owns Ds_total and must keep it
+    // feasible itself.
+    const double dp = std::max(Ds_total(offset), 0.0);
 
     auto& p_var = ivc_.get("p");
     p_var.scalar() = p_var.scalar_start() + dp;
@@ -225,6 +242,40 @@ bool PlasticityMechanism::refresh_state(
     auto& EP_var = ivc_.get("EP");
     EP_var.raw_voigt() = EP_var.raw_voigt_start() + dp * n;
     return true;
+}
+
+double PlasticityMechanism::state_drift(const arma::vec& sigma) const {
+    // Committed Dp from the (projected) internal variable, not the raw FB
+    // row — update() enforces p >= p_start, the state is the truth.
+    const double dp = ivc_.get("p").delta_scalar();
+    const arma::vec dEP = ivc_.get("EP").delta_vec();
+    if (dp < simcoon::iota && norm_strain(dEP) < simcoon::iota) {
+        // inert increment: avoid evaluating the flow direction at a
+        // possibly-zero stress
+        return 0.0;
+    }
+    // norm_strain (tensorial norm of an engineering-Voigt strain): arma::norm
+    // would weight the shear entries sqrt(2) too heavy against the cap.
+    // The absolute denominator floor keeps the relative measure from
+    // amplifying a numerically negligible EP residue at near-zero Dp (see
+    // the constant above for its calibration).
+    const arma::vec n = flow_direction(sigma);
+    return norm_strain(dEP - dp * n)
+         / std::max(dp * norm_strain(n), drift_scale_floor);
+}
+
+double PlasticityMechanism::drift_tolerance() const {
+    return yield_->has_stable_flow_direction()
+        ? StrainMechanism::drift_tolerance()
+        : std::numeric_limits<double>::infinity();
+}
+
+double PlasticityMechanism::multiplier_cap() const {
+    return 1.0;
+}
+
+double PlasticityMechanism::committed_multiplier() const {
+    return ivc_.get("p").delta_scalar();
 }
 
 void PlasticityMechanism::compute_jacobian_contribution(

--- a/src/Continuum_mechanics/Umat/Modular/yield_criterion.cpp
+++ b/src/Continuum_mechanics/Umat/Modular/yield_criterion.cpp
@@ -188,6 +188,22 @@ bool YieldCriterion::has_flow_hessian() const noexcept {
     }
 }
 
+bool YieldCriterion::has_stable_flow_direction() const noexcept {
+    // Exhaustive on purpose (no default): a criterion added to YieldType
+    // must make this choice explicitly — the compiler flags the omission.
+    switch (type_) {
+        case YieldType::VON_MISES:
+        case YieldType::HILL:
+        case YieldType::ANISOTROPIC:
+            return true;
+        case YieldType::TRESCA:   // vertex flow
+        case YieldType::DRUCKER:  // pressure-sensitive
+        case YieldType::DFA:      // pressure-sensitive
+            return false;
+    }
+    return false;  // unreachable for a valid YieldType
+}
+
 arma::mat YieldCriterion::flow_hessian(const arma::vec& sigma) const {
     if (!configured_) {
         throw std::runtime_error("YieldCriterion: not configured");

--- a/test/Umats/HYPER/THYPER.cpp
+++ b/test/Umats/HYPER/THYPER.cpp
@@ -22,7 +22,6 @@
 #include <gtest/gtest.h>
 #include <iostream>
 #include <fstream>
-#include <filesystem>
 #include <string>
 #include <assert.h>
 #include <math.h>
@@ -87,19 +86,17 @@ TEST(THYPER, HYPER_solver )
         
         cout << "run " << materialfile << endl;
 
-        try {
-            std::filesystem::copy(output_file, comparison_file, std::filesystem::copy_options::overwrite_existing);
-            std::cout << "File copied successfully to " << comparison_file << std::endl;
-        } catch (std::filesystem::filesystem_error& e) {
-            std::cerr << "Error: " << e.what() << std::endl;
-        }
-
+        // Fresh output vs the TRACKED reference — never overwrite the
+        // reference from the run (that made the comparison self-passing and
+        // churned the committed .dat files on every local test run).
         mat C;
-        C.load(comparison_file);
+        ASSERT_TRUE(C.load(comparison_file)) << "missing reference " << comparison_file;
 
         mat R;
-        R.load(output_file);
-            
+        ASSERT_TRUE(R.load(output_file)) << "missing output " << output_file;
+
+        ASSERT_EQ(C.n_rows, R.n_rows) << materialfile;
+        ASSERT_EQ(C.n_cols, R.n_cols) << materialfile;
         for (unsigned int i=0; i<C.n_rows; i++) {
             for (unsigned int j=0; j<C.n_cols; j++) {
                     EXPECT_LT(fabs(C(i,j) - R(i,j)),1.E-6);


### PR DESCRIPTION
Use the absolute SCCACHE_PATH (forward-slash normalized) for CMake compiler launchers, enable SCCACHE_IDLE_TIMEOUT=0 and set CMAKE_GENERATOR=Ninja so scikit-build-core picks Ninja. Install/ensure ninja on Windows, show sccache stats after builds, and update CMake invocations to use the SCCACHE_PATH on Unix/Windows. Also add new documentation for the modular Python builder and include it in the simulation docs index (docs/simulation/modular_python.rst, index.rst).