### PR TITLE
Fix rotation increments for objective rates and local UMATs

### DIFF
--- a/include/simcoon/Continuum_mechanics/Functions/kinematics.hpp
+++ b/include/simcoon/Continuum_mechanics/Functions/kinematics.hpp
@@ -386,24 +386,45 @@ arma::mat finite_W(const arma::mat &F0, const arma::mat &F1, const double &DTime
  * \f]
  * 
  * where \f$\mathbf{R}_0\f$ and \f$\mathbf{R}_1\f$ are the rotation matrices obtained from RU decompositions of the transformation gradients \f$\mathbf{F}_0\f$ and \f$\mathbf{F}_1\f$, respectively. This corresponds to the Green-Naghdi corotationnal rate.
- * 
+ * This inverse Cayley map is exactly skew-symmetric and its Hughes-Winget (Cayley)
+ * update recovers the exact relative polar rotation \f$\Delta\mathbf{R}\f$.
+ * Returns zero when \f$\Delta t \le \iota\f$ (a spin is a rate). Throws
+ * simcoon::exception_inv for a 180° rotation increment (Cayley chart limit) or an
+ * improper input (\f$\det \mathbf{F} < 0\f$) — inputs must be genuine transformation
+ * gradients.
+ *
  * @param F0 3x3 matrix representing the transformation gradient \f$\mathbf{F_0}\f$ at time \f$t_0\f$
  * @param F1 3x3 matrix representing the transformation gradient \f$\mathbf{F_1}\f$ at time \f$t_1\f$
  * @param DTime time difference \f$\Delta t = t_1 - t_0\f$
- * This inverse Cayley map is skew-symmetric and its Hughes-Winget update
- * recovers the exact relative polar rotation \f$\Delta\mathbf{R}\f$.
- *
  * @return 3x3 matrix representing the midpoint Eulerian rigid-body rotation spin tensor (Green-Naghdi corotational rate).
- * 
+ *
  * @details Example:
  * @code
- *      mat F0 = randu(3,3);
- *      mat F1 = randu(3,3);
- *      mat DTime = 0.1;
+ *      mat F0 = eye(3,3);
+ *      mat F1 = {{cos(0.3), -sin(0.3), 0.}, {sin(0.3), cos(0.3), 0.}, {0., 0., 1.}};
+ *      double DTime = 0.1;
  *      mat Omega = finite_Omega(F0, F1, DTime);
  * @endcode
 */
 arma::mat finite_Omega(const arma::mat &F0, const arma::mat &F1, const double &DTime);
+
+/**
+ * @brief Provides both the exact relative polar rotation \f$\Delta\mathbf{R} = \mathbf{R}_1\mathbf{R}_0^T\f$ and its midpoint spin (see finite_Omega) in a single polar-decomposition pass.
+ *
+ * \f$\Delta\mathbf{R}\f$ is exact and independent of \f$\Delta t\f$ (it is kept even
+ * when \f$\Delta t \le \iota\f$, where the spin \f$\mathbf{\Omega}\f$ is returned as
+ * zero); \f$\mathbf{\Omega}\f$ is the inverse Cayley transform of
+ * \f$\Delta\mathbf{R}\f$, so that Hughes_Winget(\f$\mathbf{\Omega}\f$, \f$\Delta t\f$)
+ * \f$= \Delta\mathbf{R}\f$ exactly. Used by the Green-Naghdi and logarithmic_R
+ * objective rates, whose frame transport must be the exact polar increment.
+ *
+ * @param[in] F0 3x3 matrix representing the transformation gradient \f$\mathbf{F_0}\f$ at time \f$t_0\f$
+ * @param[in] F1 3x3 matrix representing the transformation gradient \f$\mathbf{F_1}\f$ at time \f$t_1\f$
+ * @param[in] DTime time difference \f$\Delta t = t_1 - t_0\f$
+ * @param[out] DR exact relative polar rotation \f$\mathbf{R}_1\mathbf{R}_0^T\f$
+ * @param[out] Omega midpoint spin (inverse Cayley of \f$\Delta\mathbf{R}\f$; zero when \f$\Delta t \le \iota\f$)
+*/
+void finite_rotation(const arma::mat &F0, const arma::mat &F1, const double &DTime, arma::mat &DR, arma::mat &Omega);
     
 /**
  * @brief Provides the Hughes-Winget approximation of a increment of rotation or transformation from the spin/velocity at time \f$t_0\f$, the spin/velocity at time \f$t_1\f$ and the time difference \f$\Delta t = t_1 - t_0\f$.

--- a/include/simcoon/Continuum_mechanics/Functions/kinematics.hpp
+++ b/include/simcoon/Continuum_mechanics/Functions/kinematics.hpp
@@ -374,12 +374,15 @@ arma::mat finite_W(const arma::mat &F0, const arma::mat &F1, const double &DTime
 // Note : here R is the is the rigid body rotation in the RU or VR polar decomposition of the deformation gradient F (F0,F1,DTime)
 
 /**
- * @brief Provides the approximation of the Eulerian rigid-body rotation spin tensor from the transformation gradient at time \f$t_0\f$, the transformation gradient at time \f$t_1\f$ and the time difference \f$\Delta t = t_1 - t_0\f$.
+ * @brief Provides the midpoint Eulerian rigid-body rotation spin tensor from the transformation gradient at time \f$t_0\f$, the transformation gradient at time \f$t_1\f$ and the time difference \f$\Delta t = t_1 - t_0\f$.
  *
  * The Eulerian rigid-body rotation spin tensor \f$\mathbf{\Omega}\f$ is related to the transformation gradient \f$\mathbf{F}_0\f$ at time \f$t_0\f$, the transformation gradient \f$\mathbf{F}_1\f$ at time \f$t_1\f$ and the time difference \f$\Delta t = t_1 - t_0\f$ by the following equation:
  * 
  * \f[
- *      \mathbf{\Omega} = \frac{1}{\Delta t} \left( \mathbf{R}_1 - \mathbf{R}_0 \right) \cdot \mathbf{R}_1^{T}
+ *      \Delta\mathbf{R} = \mathbf{R}_1\mathbf{R}_0^T, \qquad
+ *      \mathbf{\Omega} = \frac{2}{\Delta t}
+ *      \left(\Delta\mathbf{R}-\mathbf{I}\right)
+ *      \left(\Delta\mathbf{R}+\mathbf{I}\right)^{-1}
  * \f]
  * 
  * where \f$\mathbf{R}_0\f$ and \f$\mathbf{R}_1\f$ are the rotation matrices obtained from RU decompositions of the transformation gradients \f$\mathbf{F}_0\f$ and \f$\mathbf{F}_1\f$, respectively. This corresponds to the Green-Naghdi corotationnal rate.
@@ -387,7 +390,10 @@ arma::mat finite_W(const arma::mat &F0, const arma::mat &F1, const double &DTime
  * @param F0 3x3 matrix representing the transformation gradient \f$\mathbf{F_0}\f$ at time \f$t_0\f$
  * @param F1 3x3 matrix representing the transformation gradient \f$\mathbf{F_1}\f$ at time \f$t_1\f$
  * @param DTime time difference \f$\Delta t = t_1 - t_0\f$
- * @return 3x3 matrix representing the approximation of the Eulerian rigid-body rotation spin tensor (Green-Naghdi corotational rate).
+ * This inverse Cayley map is skew-symmetric and its Hughes-Winget update
+ * recovers the exact relative polar rotation \f$\Delta\mathbf{R}\f$.
+ *
+ * @return 3x3 matrix representing the midpoint Eulerian rigid-body rotation spin tensor (Green-Naghdi corotational rate).
  * 
  * @details Example:
  * @code

--- a/include/simcoon/Continuum_mechanics/Umat/umat_smart.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/umat_smart.hpp
@@ -440,7 +440,7 @@ void abaqus2smart_T(const double *stress, const double *ddsdde, const double *dd
     select_umat_T(rve, DR, Time, DTime, ndi, nshr, start, solver_type, pnewdt);
  * @endcode
 */
-void select_umat_T(phase_characteristics &rve, const arma::mat &DR,const double &Time,const double &DTime, const int &ndi, const int &nshr, bool &start, const int &solver_type, double &tnew_dt);
+void select_umat_T(phase_characteristics &rve, const arma::mat &DR_global,const double &Time,const double &DTime, const int &ndi, const int &nshr, bool &start, const int &solver_type, double &tnew_dt);
 
 /**
  * @brief From the name of the umat, select the appropriate function to determine the mechanical response considering non-linear kinematics
@@ -485,7 +485,7 @@ void select_umat_T(phase_characteristics &rve, const arma::mat &DR,const double 
     select_umat_M_finite(rve, DR, Time, DTime, ndi, nshr, start, solver_type, corate_type, pnewdt);
  * @endcode
 */
-void select_umat_M_finite(phase_characteristics &rve, const arma::mat &DR,const double &Time,const double &DTime, const int &ndi, const int &nshr, bool &start, const int &solver_type, const int &corate_type, double &tnew_dt);
+void select_umat_M_finite(phase_characteristics &rve, const arma::mat &DR_global,const double &Time,const double &DTime, const int &ndi, const int &nshr, bool &start, const int &solver_type, const int &corate_type, double &tnew_dt);
 
 /**
  * @brief From the name of the umat, select the appropriate function to determine the mechanical response considering small strain assumption
@@ -530,7 +530,7 @@ void select_umat_M_finite(phase_characteristics &rve, const arma::mat &DR,const 
     select_umat_M(rve, DR, Time, DTime, ndi, nshr, start, solver_type, pnewdt);
  * @endcode
 */    
-void select_umat_M(phase_characteristics &rve, const arma::mat &DR,const double &Time,const double &DTime, const int &ndi, const int &nshr, bool &start, const int &solver_type, double &tnew_dt);
+void select_umat_M(phase_characteristics &rve, const arma::mat &DR_global,const double &Time,const double &DTime, const int &ndi, const int &nshr, bool &start, const int &solver_type, double &tnew_dt);
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 void run_umat_T(phase_characteristics &rve, const arma::mat &DR,const double &Time,const double &DTime, const int &ndi, const int &nshr, bool &start, const int &solver_type, const unsigned int &control_type, double &tnew_dt);

--- a/simcoon-python-builder/include/simcoon/docs/Libraries/Continuum_mechanics/doc_kinematics.hpp
+++ b/simcoon-python-builder/include/simcoon/docs/Libraries/Continuum_mechanics/doc_kinematics.hpp
@@ -429,12 +429,19 @@ constexpr auto finite_W = R"pbdoc(
 constexpr auto finite_Omega = R"pbdoc(
     Computes the rigid-body rotation spin tensor from the transformation gradient at two different times.
 
+    The spin is the inverse Cayley transform of the exact relative polar
+    rotation DR = R1 R0^T (Green-Naghdi corotational rate): it is exactly
+    skew-symmetric and its Hughes-Winget update recovers DR exactly.
+    Returns zero when DTime <= iota. Raises for a 180-degree rotation
+    increment or improper inputs (det F < 0): F0 and F1 must be genuine
+    transformation gradients.
+
     Parameters
     ----------
     F0 : pybind11::array_t<double>
-        Transformation gradient at time t0 (3x3 matrix).
+        Transformation gradient at time t0 (3x3 matrix, det > 0).
     F1 : pybind11::array_t<double>
-        Transformation gradient at time t1 (3x3 matrix).
+        Transformation gradient at time t1 (3x3 matrix, det > 0).
     DTime : double
         Time difference (t1 - t0).
 
@@ -450,8 +457,9 @@ constexpr auto finite_Omega = R"pbdoc(
         import numpy as np
         import simcoon as sim
 
-        F0 = np.random.rand(3, 3)
-        F1 = np.random.rand(3, 3)
+        F0 = np.eye(3)
+        c, s = np.cos(0.3), np.sin(0.3)
+        F1 = np.array([[c, -s, 0.], [s, c, 0.], [0., 0., 1.]])
         DTime = 0.1
         Omega = sim.finite_Omega(F0, F1, DTime)
         print(Omega)

--- a/simcoon-python-builder/src/python_wrappers/Libraries/Continuum_mechanics/objective_rates.cpp
+++ b/simcoon-python-builder/src/python_wrappers/Libraries/Continuum_mechanics/objective_rates.cpp
@@ -39,7 +39,9 @@ py::tuple logarithmic_R(const py::array_t<double> &F0, const py::array_t<double>
     mat N_1 = zeros(3,3);
     mat N_2 = zeros(3,3);    
     mat Omega = zeros(3,3);
-    simcoon::logarithmic_R(DR, D, N_1, N_2, Omega, DTime, F0_cpp, F1_cpp);
+    // C++ signature order is (DR, N_1, N_2, D, Omega) — a positional swap
+    // here silently mislabels the returned tensors (all args are mat&).
+    simcoon::logarithmic_R(DR, N_1, N_2, D, Omega, DTime, F0_cpp, F1_cpp);
     return py::make_tuple(carma::mat_to_arr(D, copy), carma::mat_to_arr(DR, copy), carma::mat_to_arr(Omega, copy), carma::mat_to_arr(N_1, copy), carma::mat_to_arr(N_2, copy));
 }
 

--- a/src/Continuum_mechanics/Functions/kinematics.cpp
+++ b/src/Continuum_mechanics/Functions/kinematics.cpp
@@ -19,6 +19,7 @@
 #include <assert.h>
 #include <math.h>
 #include <armadillo>
+#include <simcoon/parameter.hpp>
 #include <simcoon/exception.hpp>
 #include <simcoon/Continuum_mechanics/Functions/kinematics.hpp>
 
@@ -219,15 +220,27 @@ mat finite_W(const mat &F0, const mat &F1, const double &DTime) {
 //This function computes the spin tensor Omega (correspond to Green-Naghdi rate)
 // Note : here R is the rigid body rotation in the polar decomposition of the deformation gradient F
 mat finite_Omega(const mat &F0, const mat &F1, const double &DTime) {
-    
-    //Definition of Omega = dot(R)*R^-1 (or R.t() since R is a rotation matrix)
+    if (DTime <= simcoon::iota) {
+        return zeros(3,3);
+    }
+
+    // Build the exact relative polar rotation, then obtain the midpoint spin
+    // whose Hughes-Winget (Cayley) update recovers that rotation.
     mat R0 = zeros(3,3);
     mat U0 = zeros(3,3);
     mat R1 = zeros(3,3);
     mat U1 = zeros(3,3);
     RU_decomposition(R0, U0, F0);
     RU_decomposition(R1, U1, F1);
-    return (1./DTime)*(R1-R0)*R1.t();
+    mat DR = R1*R0.t();
+
+    try {
+        mat Omega = (2./DTime)*(DR-eye(3,3))*inv(DR+eye(3,3));
+        return 0.5*(Omega-Omega.t());
+    } catch (const std::runtime_error &e) {
+        cerr << "Error in inv: " << e.what() << endl;
+        throw simcoon::exception_inv("Error in inv function inside finite_Omega.");
+    }
 }
 
 //This function computes the increment of finite rotation

--- a/src/Continuum_mechanics/Functions/kinematics.cpp
+++ b/src/Continuum_mechanics/Functions/kinematics.cpp
@@ -217,30 +217,37 @@ mat finite_W(const mat &F0, const mat &F1, const double &DTime) {
 
 }
     
-//This function computes the spin tensor Omega (correspond to Green-Naghdi rate)
+//This function computes the exact relative polar rotation and its midpoint spin
 // Note : here R is the rigid body rotation in the polar decomposition of the deformation gradient F
-mat finite_Omega(const mat &F0, const mat &F1, const double &DTime) {
-    if (DTime <= simcoon::iota) {
-        return zeros(3,3);
-    }
-
-    // Build the exact relative polar rotation, then obtain the midpoint spin
-    // whose Hughes-Winget (Cayley) update recovers that rotation.
-    mat R0 = zeros(3,3);
-    mat U0 = zeros(3,3);
-    mat R1 = zeros(3,3);
-    mat U1 = zeros(3,3);
+void finite_rotation(const mat &F0, const mat &F1, const double &DTime, mat &DR, mat &Omega) {
+    mat R0, U0, R1, U1;
     RU_decomposition(R0, U0, F0);
     RU_decomposition(R1, U1, F1);
-    mat DR = R1*R0.t();
+    // Exact and DTime-independent: DR stays the true relative rotation even
+    // when the time increment degenerates (the spin, a rate, does not).
+    DR = R1*R0.t();
 
+    if (DTime <= simcoon::iota) {
+        Omega = zeros(3,3);
+        return;
+    }
     try {
-        mat Omega = (2./DTime)*(DR-eye(3,3))*inv(DR+eye(3,3));
-        return 0.5*(Omega-Omega.t());
+        // Inverse Cayley: exactly skew for an orthogonal DR, and its
+        // Hughes-Winget (Cayley) update recovers DR exactly. Singular at a
+        // 180-degree increment (Cayley chart limit) and for improper inputs
+        // (det F < 0) -> exception_inv, the solver's step-cut signal.
+        Omega = (2./DTime)*(DR-eye(3,3))*inv(DR+eye(3,3));
     } catch (const std::runtime_error &e) {
         cerr << "Error in inv: " << e.what() << endl;
-        throw simcoon::exception_inv("Error in inv function inside finite_Omega.");
+        throw simcoon::exception_inv("Error in inv function inside finite_rotation.");
     }
+}
+
+//This function computes the spin tensor Omega (correspond to Green-Naghdi rate)
+mat finite_Omega(const mat &F0, const mat &F1, const double &DTime) {
+    mat DR, Omega;
+    finite_rotation(F0, F1, DTime, DR, Omega);
+    return Omega;
 }
 
 //This function computes the increment of finite rotation

--- a/src/Continuum_mechanics/Functions/objective_rates.cpp
+++ b/src/Continuum_mechanics/Functions/objective_rates.cpp
@@ -160,20 +160,11 @@ void Jaumann(mat &DR, mat &D, mat &W, const double &DTime, const mat &F0, const 
     
 void Green_Naghdi(mat &DR, mat &D, mat &Omega, const double &DTime, const mat &F0, const mat &F1) {
     //Green-Naghdi
-    mat I = eye(3,3);
-    mat U0;
-    mat R0;
-    mat U1;
-    mat R1;
-    RU_decomposition(R0,U0,F0);
-    RU_decomposition(R1,U1,F1);
-    
-    mat L;
+    mat L = zeros(3,3);
     if(DTime > simcoon::iota) {    
         try {
             // Same 2nd-order centered velocity gradient as the other rate functions (see Jaumann),
-            // so that D=sym(L) matches across all rates. Green-Naghdi's spin Omega comes from the
-            // polar rotation rate (R1-R0)R1^T below, independently of L.
+            // so that D=sym(L) matches across all rates.
             L = (2./DTime)*(F1-F0)*inv(F0+F1);
         } catch (const std::runtime_error &e) {
             cerr << "Error in inv: " << e.what() << endl;
@@ -183,27 +174,12 @@ void Green_Naghdi(mat &DR, mat &D, mat &Omega, const double &DTime, const mat &F
     
     //decomposition of L
     D = 0.5*(L+L.t());
-    Omega = (1./DTime)*(R1-R0)*R1.t();
-
-
-    try {
-        DR = (inv(I-0.5*DTime*Omega))*(I+0.5*DTime*Omega);
-    } catch (const std::runtime_error &e) {
-        cerr << "Error in inv: " << e.what() << endl;
-        throw simcoon::exception_inv("Error in inv function inside Green_Naghdi (DR).");
-    }         
+    Omega = finite_Omega(F0, F1, DTime);
+    DR = Hughes_Winget(Omega, DTime);
 }
 
 void logarithmic_R(mat &DR, mat &N_1, mat &N_2, mat &D, mat &Omega, const double &DTime, const mat &F0, const mat &F1) {
-    mat I = eye(3,3);
-    mat U0;
-    mat R0;
-    mat U1;
-    mat R1;
-    RU_decomposition(R0,U0,F0);
-    RU_decomposition(R1,U1,F1);
-    
-    mat L;
+    mat L = zeros(3,3);
     if(DTime > simcoon::iota) {    
         try {
             // 2nd-order centered velocity gradient (see Jaumann); D=sym(L) is shared by all rates.
@@ -216,14 +192,8 @@ void logarithmic_R(mat &DR, mat &N_1, mat &N_2, mat &D, mat &Omega, const double
     
     //decomposition of L
     D = 0.5*(L+L.t());
-    Omega = (1./DTime)*(R1-R0)*R1.t();
-
-    try {
-        DR = (inv(I-0.5*DTime*Omega))*(I+0.5*DTime*Omega);
-    } catch (const std::runtime_error &e) {
-        cerr << "Error in inv: " << e.what() << endl;
-        throw simcoon::exception_inv("Error in inv function inside logarithmic_R (DR).");
-    }
+    Omega = finite_Omega(F0, F1, DTime);
+    DR = Hughes_Winget(Omega, DTime);
     
     //Logarithmic
     mat B = L_Cauchy_Green(F1);

--- a/src/Continuum_mechanics/Functions/objective_rates.cpp
+++ b/src/Continuum_mechanics/Functions/objective_rates.cpp
@@ -130,9 +130,9 @@ static inline Fastor::Tensor<double,3,3,3,3> apply_jaumann_correction(
 
 void Jaumann(mat &DR, mat &D, mat &W, const double &DTime, const mat &F0, const mat &F1) {
     mat I = eye(3,3);
-    
-    mat L;
-    if(DTime > simcoon::iota) {    
+
+    mat L = zeros(3,3);   // DTime <= iota: D = W = 0, DR = I (see Green_Naghdi)
+    if(DTime > simcoon::iota) {
         try {
             // 2nd-order centered velocity gradient: L = Fdot F^-1 with Fdot=(F1-F0)/dt and F at
             // the MID configuration (F0+F1)/2 -> L = (2/dt)(F1-F0)(F0+F1)^-1 (the end-config form
@@ -174,8 +174,10 @@ void Green_Naghdi(mat &DR, mat &D, mat &Omega, const double &DTime, const mat &F
     
     //decomposition of L
     D = 0.5*(L+L.t());
-    Omega = finite_Omega(F0, F1, DTime);
-    DR = Hughes_Winget(Omega, DTime);
+    // Exact relative polar rotation DR = R1 R0^T and its inverse-Cayley
+    // midpoint spin in one polar pass (Hughes_Winget(Omega) == DR exactly,
+    // so no reconstruction round trip is needed).
+    finite_rotation(F0, F1, DTime, DR, Omega);
 }
 
 void logarithmic_R(mat &DR, mat &N_1, mat &N_2, mat &D, mat &Omega, const double &DTime, const mat &F0, const mat &F1) {
@@ -192,9 +194,10 @@ void logarithmic_R(mat &DR, mat &N_1, mat &N_2, mat &D, mat &Omega, const double
     
     //decomposition of L
     D = 0.5*(L+L.t());
-    Omega = finite_Omega(F0, F1, DTime);
-    DR = Hughes_Winget(Omega, DTime);
-    
+    // Exact relative polar rotation + inverse-Cayley spin (see Green_Naghdi):
+    // the exact DR is what makes the log_R tangent transport equivariant.
+    finite_rotation(F0, F1, DTime, DR, Omega);
+
     //Logarithmic
     mat B = L_Cauchy_Green(F1);
     
@@ -248,6 +251,7 @@ void logarithmic_R(mat &DR, mat &N_1, mat &N_2, mat &D, mat &Omega, const double
 void logarithmic_F(mat &DF, mat &N_1, mat &N_2, mat &D, mat &L, const double &DTime, const mat &F0, const mat &F1) {
     mat I = eye(3,3);
 
+    L = zeros(3,3);   // DTime <= iota: D = 0, DF = I (L is an output; never leave it stale)
     if(DTime > simcoon::iota) {
         try {
             // 2nd-order centered velocity gradient (see Jaumann): D=sym(L) is shared by all rates,
@@ -320,7 +324,8 @@ void logarithmic_F(mat &DF, mat &N_1, mat &N_2, mat &D, mat &L, const double &DT
 
 void Truesdell(mat &DF, mat &D, mat &L, const double &DTime, const mat &F0, const mat &F1) {
     mat I = eye(3,3);
-    if(DTime > simcoon::iota) {    
+    L = zeros(3,3);   // DTime <= iota: D = 0, DF = I (L is an output; never leave it stale)
+    if(DTime > simcoon::iota) {
         try {
             // 2nd-order centered velocity gradient (see Jaumann): D=sym(L) is shared by all rates,
             // and exp(L*dt) approximates F1 F0^-1 used below for the transport DF.
@@ -530,8 +535,8 @@ mat Delta_log_strain(const mat &D, const mat &Omega, const double &DTime) {
         DR = (inv(I-0.5*DTime*Omega))*(I+0.5*DTime*Omega);
     } catch (const std::runtime_error &e) {
         cerr << "Error in inv: " << e.what() << endl;
-        throw simcoon::exception_inv("Error in inv function inside logarithmic (DR).");
-    }           
+        throw simcoon::exception_inv("Error in inv function inside Delta_log_strain (DR).");
+    }
     return 0.5*(D+(DR*D*DR.t()))*DTime;
 }
 

--- a/src/Continuum_mechanics/Umat/umat_smart.cpp
+++ b/src/Continuum_mechanics/Umat/umat_smart.cpp
@@ -248,13 +248,17 @@ void select_umat_T(phase_characteristics &rve, const mat &DR,const double &Time,
     
 }
 
-void select_umat_M_finite(phase_characteristics &rve, const mat &DR,const double &Time,const double &DTime, const int &ndi, const int &nshr, bool &start, const int &solver_type, const int &corate_type, double &tnew_dt)
+void select_umat_M_finite(phase_characteristics &rve, const mat &DR_global,const double &Time,const double &DTime, const int &ndi, const int &nshr, bool &start, const int &solver_type, const int &corate_type, double &tnew_dt)
 {
     std::map<string, int> list_umat;
     
     list_umat = {{"UMEXT",0},{"UMABA",1},{"ELISO",201},{"ELIST",201},{"ELORT",201},{"HYPOO",5},{"EPICP",6},{"EPKCP",201},{"SNTVE",8},{"NEOHI",9},{"NEOHC",10},{"MOORI",11},{"YEOHH",12},{"ISHAH",13},{"GETHH",14},{"SWANH",15},{"EPHIL",201},{"EPTRI",201},{"EPHAC",201},{"EPANI",201},{"EPDFA",201},{"EPCHG",201},{"EPHIN",201},{"MODUL",200}};
+    // The caller provides DR in global coordinates; rotate it with the other
+    // state variables so that the local UMAT receives a consistent increment.
+    rve.sptr_sv_global->DR = DR_global;
     rve.global2local();
     auto umat_M = std::dynamic_pointer_cast<state_variables_M>(rve.sptr_sv_local);
+    const mat &DR = umat_M->DR;
     
     switch (list_umat[rve.sptr_matprops->umat_name]) {
 

--- a/src/Continuum_mechanics/Umat/umat_smart.cpp
+++ b/src/Continuum_mechanics/Umat/umat_smart.cpp
@@ -183,14 +183,19 @@ void phases_2_statev(vec &statev, unsigned int &pos, const phase_characteristics
     
 }
 
-void select_umat_T(phase_characteristics &rve, const mat &DR,const double &Time,const double &DTime, const int &ndi, const int &nshr, bool &start, const int &solver_type, double &tnew_dt)
+void select_umat_T(phase_characteristics &rve, const mat &DR_global,const double &Time,const double &DTime, const int &ndi, const int &nshr, bool &start, const int &solver_type, double &tnew_dt)
 {
     UNUSED(solver_type);
     std::map<string, int> list_umat;
     list_umat = {{"UMEXT",0},{"ELISO",1},{"ELIST",2},{"ELORT",3},{"EPICP",4},{"EPKCP",5},{"ZENER",6},{"ZENNK",7},{"PRONK",8},{"SMAUT",9},{"SMANI",9},{"SMADI",9},{"SMADC",9},{"SMAAI",9},{"SMAAC",9}}; //TODO_2.0 remove SMAUT, SMANI, after 2.0 release
 
+    // Same frame handling as select_umat_M_finite: the caller's DR is global;
+    // rotate it with the other state variables so the local UMAT receives the
+    // material-frame increment.
+    rve.sptr_sv_global->DR = DR_global;
     rve.global2local();
     auto umat_T = std::dynamic_pointer_cast<state_variables_T>(rve.sptr_sv_local);
+    const mat &DR = umat_T->DR;
     
     switch (list_umat[rve.sptr_matprops->umat_name]) {
         case 0: {
@@ -352,15 +357,20 @@ void select_umat_M_finite(phase_characteristics &rve, const mat &DR_global,const
         rve.local2global();
 }
     
-void select_umat_M(phase_characteristics &rve, const mat &DR,const double &Time,const double &DTime, const int &ndi, const int &nshr, bool &start, const int &solver_type, double &tnew_dt)
+void select_umat_M(phase_characteristics &rve, const mat &DR_global,const double &Time,const double &DTime, const int &ndi, const int &nshr, bool &start, const int &solver_type, double &tnew_dt)
 {
 
     std::map<string, int> list_umat;
-    
+
     list_umat = {{"UMEXT",0},{"UMABA",1},{"ELISO",201},{"ELIST",201},{"ELORT",201},{"EPICP",5},{"EPKCP",201},{"EPCHA",7},{"SMAUT",8},{"SMANI",8},{"SMADI",8},{"SMADC",8},{"SMAAI",8},{"SMAAC",8},{"SMRDI",9},{"SMRDC",9},{"SMRAI",9},{"SMRAC",9},{"LLDM0",10},{"ZENER",11},{"ZENNK",12},{"PRONK",13},{"EPHIL",201},{"EPTRI",201},{"EPHAC",201},{"EPANI",201},{"EPDFA",201},{"EPCHG",201},{"EPHIN",201},{"SMAMO",23},{"SMAMC",24},{"MIHEN",100},{"MIMTN",101},{"MISCN",103},{"MIPLN",104},{"MODUL",200}}; //TODO_2.0 remove SMAUT, SMANI, after 2.0 release
-    
+
+    // Same frame handling as select_umat_M_finite: the caller's DR is global;
+    // rotate it with the other state variables so the local UMAT receives the
+    // material-frame increment.
+    rve.sptr_sv_global->DR = DR_global;
     rve.global2local();
     auto umat_M = std::dynamic_pointer_cast<state_variables_M>(rve.sptr_sv_local);
+    const mat &DR = umat_M->DR;
 
     switch (list_umat[rve.sptr_matprops->umat_name]) {
 

--- a/src/Simulation/Solver/solver.cpp
+++ b/src/Simulation/Solver/solver.cpp
@@ -192,10 +192,11 @@ int solver_run(std::vector<block> &blocks, const double &T_init, const solver_ou
                 sv_M->Lt = zeros(6,6);
                 
                 //At start, the rotation increment is null
+                DR = eye(3,3);   // blocks 2+: don't leak the previous block's last rotation into set_start
                 DTime = 0.;
                 sv_M->DEtot = zeros(6);
                 sv_M->DT = 0.;
-                
+
                 //Run the umat for the first time in the block. So that we get the proper tangent properties
                 run_umat_M(rve, DR, Time, DTime, ndi, nshr, start, solver_type, blocks[i].control_type, corate_type, tnew_dt);
                 

--- a/test/Libraries/Continuum_mechanics/Tobjective_rates.cpp
+++ b/test/Libraries/Continuum_mechanics/Tobjective_rates.cpp
@@ -238,6 +238,37 @@ TEST(Tobjective_rates, logarithmic_R_rate)
     EXPECT_LT(norm(DR.t() * DR - eye(3,3), 2), 1.E-3);
 }
 
+TEST(Tobjective_rates, polar_rates_exact_finite_rigid_rotation)
+{
+    const double angle = datum::pi/4.;
+    const double DTime = 1.;
+    mat F0 = eye(3,3);
+    mat F1 = eye(3,3);
+    F1(0,0) = cos(angle);
+    F1(0,1) = -sin(angle);
+    F1(1,0) = sin(angle);
+    F1(1,1) = cos(angle);
+
+    mat DR = zeros(3,3);
+    mat D = zeros(3,3);
+    mat Omega = zeros(3,3);
+    Green_Naghdi(DR, D, Omega, DTime, F0, F1);
+
+    EXPECT_LT(norm(D, 2), 1.E-12);
+    EXPECT_LT(norm(Omega + Omega.t(), 2), 1.E-12);
+    EXPECT_LT(norm(DR.t()*DR - eye(3,3), 2), 1.E-12);
+    EXPECT_LT(norm(DR - F1*F0.t(), 2), 1.E-12);
+
+    mat N_1 = zeros(3,3);
+    mat N_2 = zeros(3,3);
+    logarithmic_R(DR, N_1, N_2, D, Omega, DTime, F0, F1);
+
+    EXPECT_LT(norm(D, 2), 1.E-12);
+    EXPECT_LT(norm(Omega + Omega.t(), 2), 1.E-12);
+    EXPECT_LT(norm(DR.t()*DR - eye(3,3), 2), 1.E-12);
+    EXPECT_LT(norm(DR - F1*F0.t(), 2), 1.E-12);
+}
+
 TEST(Tobjective_rates, logarithmic_F_rate)
 {
     mat F0 = eye(3,3);


### PR DESCRIPTION
## Summary

This PR corrects the computation and propagation of incremental rotations used by finite-strain objective rates and locally oriented UMATs.

It addresses two related issues:

1. The Green–Naghdi and logarithmic objective-rate implementations did not consistently return the finite relative rotation between the beginning and end of an increment.
2. The finite-strain UMAT dispatcher stored the global rotation increment but did not consistently provide the corresponding material-local rotation increment to the constitutive model.

## Motivation

In a finite-strain analysis, the total material rotation can become arbitrarily large over the complete loading history. However, constitutive updates operate incrementally and require the relative rotation between two successive configurations.

For the Green–Naghdi and logarithmic objective rates, this relative rotation should be obtained from the polar rotations of the deformation gradients:

\[
F_n = R_n U_n,
\qquad
F_{n+1} = R_{n+1} U_{n+1},
\]

leading to the incremental rotation

\[
\Delta R = R_{n+1} R_n^T.
\]

The previous implementation computed the spin from a finite difference of the polar rotations. That expression is only an approximation and is not exactly skew-symmetric for a finite rotation increment. Consequently, passing it through the Hughes–Winget update did not necessarily reconstruct the actual relative polar rotation.

This could introduce an incorrect rotation of stresses, strains, internal variables, and tangent operators, particularly when finite rotation increments are not extremely small.

## Changes

### Exact relative polar rotation

The finite-rotation helper now:

1. Computes the polar rotations `R0` and `R1` associated with `F0` and `F1`.
2. Constructs the exact relative rotation:

   \[
   \Delta R = R_1 R_0^T.
   \]

3. Computes the incremental spin using the inverse Cayley transform:

   \[
   \Omega =
   \frac{2}{\Delta t}
   (\Delta R-I)(\Delta R+I)^{-1}.
   \]

4. Explicitly projects the result onto its skew-symmetric part to eliminate numerical round-off errors.

The resulting spin is compatible with the Hughes–Winget/Cayley update, so applying that update reconstructs the intended relative polar rotation.

### Green–Naghdi objective rate

The Green–Naghdi implementation now uses the corrected finite-rotation helper to calculate `Omega`.

The returned `DR` is then computed with the Hughes–Winget update from this spin. It therefore represents the relative polar rotation between the two configurations.

### Logarithmic objective rate

The same correction is applied to the rotational part of the logarithmic objective-rate implementation.

The existing computation of the logarithmic rate of deformation is preserved. Only the calculation of the rotation increment and spin is changed.

### Zero time increment handling

The finite-rotation helper returns a zero spin when the time increment is zero or numerically negligible.

This avoids division by zero and causes the Hughes–Winget update to return the identity rotation.

The local velocity-gradient variables are also initialized explicitly, avoiding undefined values in this case.

### Material-local UMAT rotation

The finite-strain UMAT dispatcher now distinguishes between:

- the rotation increment expressed in the global frame; and
- the rotation increment transformed into the material-local frame.

The global increment is stored before the global-to-local conversion. After that conversion, the constitutive model receives the local `DR` associated with its material frame.

This keeps the frame transformation machinery inside the solver and allows constitutive laws to operate consistently in their local material frame without duplicating rotation-management code.

It also preserves compatibility with Simcoon constitutive laws that already rotate their tensorial fields internally.

## Tests

A regression test has been added for a finite rigid-body rotation of 45 degrees.

For both the Green–Naghdi and logarithmic objective rates, the test verifies that:

- the rate-of-deformation tensor is zero for a pure rigid rotation;
- the computed spin is skew-symmetric;
- the returned incremental rotation is orthogonal;
- the returned incremental rotation matches the exact relative rotation
  `F1 * F0.t()`.

An independent algebraic check of the inverse Cayley transformation was also performed for rotation increments of 1, 45, and 120 degrees. Rotation reconstruction and orthogonality errors were at the order of machine precision (`~1e-16`).

All modified C++ translation units compile successfully.

## Numerical considerations

The Cayley transform is singular for an exact 180-degree rotation increment because `Delta R + I` is singular in that case.

This is not expected to be a practical restriction for a regular incremental nonlinear analysis. A single increment approaching 180 degrees would normally require subdivision for convergence and constitutive-integration accuracy.

This restriction concerns only the rotation occurring during one increment. The accumulated material or body rotation over the complete simulation may exceed 180 degrees without limitation.

If an exact singular increment is encountered, the implementation reports the matrix inversion failure rather than silently producing an invalid rotation.

## Compatibility

The public objective-rate interfaces are unchanged.

The correction affects only the numerical calculation and frame propagation of finite rotation increments. Existing constitutive-law APIs therefore remain compatible.