### PR TITLE
Add PYEXT: constitutive laws written in Python, driven by the C++ solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,6 @@ pip install scikit-build-core pybind11 numpy  # build dependencies
 pip install simcoon --no-binary simcoon --no-build-isolation
 ```
 
-Using Homebrew (macOS):
-```bash
-brew install armadillo
-pip install simcoon --no-binary simcoon
-```
-
 Using apt (Debian/Ubuntu):
 ```bash
 sudo apt-get install libarmadillo-dev
@@ -138,11 +132,7 @@ cd simcoon
 sudo apt-get install libarmadillo-dev libgtest-dev ninja-build
 ```
 
-- On macOS with Homebrew:
-
-```bash
-brew install armadillo googletest
-```
+- On macOS: use the conda environment (`environment_arm64.yml`, conda-forge armadillo and gtest). Do not use Homebrew packages inside a conda environment: they bring a second OpenMP runtime (see the installation docs, "Duplicate OpenMP runtimes on macOS"; check with `python -m simcoon.doctor`).
 
 - On Windows with vcpkg:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -59,36 +59,47 @@ while BLAS handles internal threading.
 Duplicate OpenMP runtimes on macOS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Only **one** OpenMP runtime may be active per process. Two common setups load
-a second one next to simcoon's:
+**The rule: one environment = one OpenMP runtime.** In a conda environment that
+runtime is conda-forge's ``llvm-openmp`` (``libomp.dylib``), and every native
+package must share it. Two setups break the rule:
 
-- the **PyPI wheel** bundles its own ``libomp`` (via delocate); if numpy/scipy
-  come from **conda**, they load the conda environment's ``libomp`` as well;
-- a **source build** that picks the Homebrew Armadillo pulls Homebrew's
-  ``libomp`` through its OpenBLAS, while conda numpy loads the environment's.
+- a **PyPI wheel** that bundles its own ``libomp`` (PyTorch wheels do; the
+  simcoon wheel does, via delocate) next to conda numpy/scipy/simcoon;
+- a **source build** of simcoon linked against an Armadillo that does not come
+  from the environment (a system or Homebrew copy): its OpenBLAS drags a second
+  ``libomp`` into the process.
 
-Symptoms range from the explicit Intel abort message ("multiple copies of the
-OpenMP runtime have been linked") to silent crashes (``SIGSEGV`` inside
-``libomp`` worker threads under threaded runs). Remedies, in order of
-preference:
+Symptoms range from the explicit abort message (``OMP: Error #15: Initializing
+libomp.dylib, but found libomp.dylib already initialized``) to silent crashes
+(``SIGSEGV`` inside ``libomp`` worker threads under threaded runs).
 
-1. **Stay on one channel**: install simcoon *and* numpy/scipy from
-   conda-forge (everything links the same ``llvm-openmp``), or everything
-   from PyPI wheels.
-2. **Source builds in a conda environment**: point CMake at the environment's
-   Armadillo so simcoon shares the environment's OpenMP runtime:
+What to do:
+
+1. **conda-forge for everything native**: simcoon, numpy, scipy, armadillo and
+   PyTorch (``conda install -c conda-forge pytorch``, not ``pip install torch``).
+   Do not mix in Homebrew or system libraries.
+2. **Source builds in a conda environment** pick the environment's Armadillo
+   automatically (CMake detects ``CONDA_PREFIX``) and warn when they do not.
+   Install it first and purge any stale build cache when switching:
 
    .. code-block:: bash
 
        conda install -c conda-forge armadillo
-       CMAKE_ARGS="-DArmadillo_ROOT=$CONDA_PREFIX" pip install -e . --no-build-isolation
+       rm -rf build/           # a cached non-conda Armadillo path would be kept otherwise
+       pip install -e . --no-build-isolation
 
-   (a plain build on a machine with Homebrew Armadillo links Homebrew's
-   ``libomp`` instead — remove the stale ``build/`` cache when switching).
-3. **Last resort**: ``export KMP_DUPLICATE_LIB_OK=TRUE`` silences the guard
-   but does **not** make the process safe — crashes or silently wrong results
-   remain possible (this is Intel's own warning). If you must use it, also
-   set ``OMP_NUM_THREADS=1`` to keep the second runtime quiescent.
+3. **Check** which runtimes a process really loads:
+
+   .. code-block:: bash
+
+       python -m simcoon.doctor
+
+   It imports numpy, scipy, simcoon and torch (if present), lists the OpenMP
+   runtimes each one brings and exits with 1 when there are several.
+
+``KMP_DUPLICATE_LIB_OK=TRUE`` is **not** a remedy: it silences the guard and
+leaves two runtimes fighting (crashes or silently wrong results remain
+possible, this is Intel's own warning).
 
 **Using MKL with conda on Linux**
 
@@ -141,17 +152,11 @@ Prerequisites (system packages)
       sudo apt-get install libarmadillo-dev libopenblas-dev liblapack-dev \
           libgtest-dev ninja-build cmake
 
-- **macOS (Homebrew):**
-
-  .. code-block:: bash
-
-      brew install armadillo ninja cmake
-
-  .. note::
-     If you develop inside a conda environment, prefer the conda-forge
-     Armadillo with ``CMAKE_ARGS="-DArmadillo_ROOT=$CONDA_PREFIX"`` — the
-     Homebrew one drags in a second OpenMP runtime next to the environment's
-     (see *Duplicate OpenMP runtimes on macOS* above).
+- **macOS:** use the conda environment (``environment_arm64.yml`` above:
+  conda-forge Armadillo, Accelerate BLAS, cmake, ninja). Do not install the
+  dependencies with Homebrew: a Homebrew Armadillo links Homebrew's OpenBLAS
+  and ``libomp``, i.e. a second OpenMP runtime next to the environment's (see
+  *Duplicate OpenMP runtimes on macOS* above).
 
 - **Windows (vcpkg):**
 

--- a/docs/simulation/identification.rst
+++ b/docs/simulation/identification.rst
@@ -222,6 +222,9 @@ Built-in metrics (numpy only, no extra dependency):
   identification.
 - ``"rmse"`` — Root Mean Squared Error
 - ``"mae"`` — Mean Absolute Error
+- ``"mape"`` — Mean Absolute Percentage Error (scikit-learn definition)
+- ``"wmape"`` — weighted MAPE, ``sum(w |y_exp - y_num|) / sum(w |y_exp|)``
+  (robust to responses crossing zero)
 
 With ``scikit-learn`` installed (``pip install simcoon[identify]``):
 

--- a/docs/simulation/index.rst
+++ b/docs/simulation/index.rst
@@ -9,6 +9,7 @@ Simulation
    python_solver.rst
    umat_catalog.rst
    modular_python.rst
+   python_umat.rst
    umat_tutorial.rst
    identification.rst
    output.rst

--- a/docs/simulation/python_solver.rst
+++ b/docs/simulation/python_solver.rst
@@ -140,6 +140,14 @@ keyword arguments: ``precision`` (default 1e-6), ``maxiter``/``miniter``,
 ``tangent_mode`` (``'none'``, ``'continuum'``, ``'algorithmic'`` — default)
 and ``solver_type``.
 
+Constitutive laws written in Python
+-----------------------------------
+
+``umat_name`` also accepts a law object implementing :class:`simcoon.PythonUMAT`
+(numpy, PyTorch, ...): it is registered under the ``PYEXT`` name for the duration
+of the call and integrated by the C++ solver like a built-in kernel; ``props`` and
+``nstatev`` default to the object's attributes. See :doc:`python_umat`.
+
 API reference
 -------------
 

--- a/docs/simulation/python_umat.rst
+++ b/docs/simulation/python_umat.rst
@@ -1,0 +1,151 @@
+=====================================
+Constitutive laws in Python (PYEXT)
+=====================================
+
+A constitutive law can be written in Python and driven by the C++ material-point
+solver exactly like a built-in kernel. The C++ side keeps the Newton loop, the
+step cutting, the start-of-increment rollback and the finite-strain kinematics;
+the Python side only integrates **one increment at one material point**. The law
+is served under the UMAT name ``PYEXT`` and reaches the C++ code through a
+process-wide callback registered by the bindings.
+
+Typical uses: a research model prototyped in numpy, a machine-learning model
+(PyTorch, JAX), or any law for which a C++ port is not worth
+the effort yet.
+
+Quick start
+===========
+
+.. code-block:: python
+
+   import numpy as np
+   import simcoon as sim
+   from simcoon.solver import StepMeca, solve
+
+   class LinearElastic(sim.PythonUMAT):
+       nstatev = 0                      # no internal variable
+
+       def __init__(self, E, nu):
+           self.L = sim.L_iso([E, nu], "Enu")
+
+       def integrate(self, *, Etot, DEtot, sigma, statev, Wm, **kw):
+           stress = self.L @ (Etot + DEtot)
+           Wm = Wm.copy()
+           Wm[0] += 0.5 * (sigma + stress) @ DEtot     # cumulative work
+           return stress, self.L, statev, Wm            # sigma, Lt, statev, Wm
+
+   step = StepMeca(control=["strain"] + ["stress"] * 5, value=[0.01, 0, 0, 0, 0, 0], ninc=50)
+   res = solve(step, LinearElastic(70000., 0.3))       # the law object replaces the name
+   res["Stress"][0, -1]                                 # 700.0
+
+``solve`` registers the object under ``PYEXT`` for the duration of the call;
+``props`` and ``nstatev`` are taken from the object (``props`` may stay empty).
+
+The contract
+============
+
+:class:`simcoon.PythonUMAT` mirrors the C++ small-strain UMAT convention. The
+``integrate`` method receives keyword arguments and returns a tuple:
+
+.. code-block:: python
+
+   def integrate(self, *, Etot, DEtot, sigma, DR, props, statev, T, DT, Time, DTime,
+                 Wm, ndi, nshr, start, tangent_mode, **_):
+       ...
+       return sigma, Lt, statev, Wm            # optionally a 5th value: L (elastic operator)
+
+* **Voigt convention**: order ``11 22 33 12 13 23``, **engineering** shear strains,
+  quantities in the material (local) frame. ``Etot`` is the strain at the beginning
+  of the increment, ``DEtot`` the increment, ``sigma`` the stress at the beginning of
+  the increment; ``DR`` is the rotation increment (identity in small strain).
+* **State**: the law must be a pure function of its arguments except through
+  ``statev`` and ``Wm``. The solver calls the same increment several times (Newton
+  iterations, step cuts) with ``statev``, ``sigma`` and ``Wm`` **reset to their
+  start-of-increment values** — nothing may be cached in the Python object between
+  calls. A recurrent model keeps its hidden state inside ``statev``.
+* **start** is ``True`` on the first call of a block (``Time == 0``); ``statev``
+  arrives zero-filled — initialise it there if needed. The solver primes the
+  tangent at the start of **every** block with a zero-increment call
+  (``DTime == 0``, ``DEtot == 0``), and finite-element couplers do the same at
+  initialisation; :class:`simcoon.PythonUMAT` treats that probe as a pure tangent
+  query: stress, ``statev`` and ``Wm`` are returned exactly as received and only
+  the tangent comes from the evaluation, so a history-dependent law does not count
+  it as a loading step (a bare callable registered instead of a ``PythonUMAT`` must
+  do it itself).
+* **ndi** follows the classical convention: 3 = 3D (plane strain is 3D with a null
+  out-of-plane strain), 2 = plane stress (the law must condense, cf. ``el_pred``),
+  1 = uniaxial. ``nshr`` is the number of shear components.
+* **tangent_mode**: 0 = return the elastic operator as ``Lt``, 1 = continuum tangent,
+  2 = algorithmic (consistent) tangent (default of the solver).
+* **Wm** is the accumulated ``(Wm, Wm_r, Wm_ir, Wm_d)`` at the beginning of the
+  increment and must be returned accumulated.
+* **Return**: ``sigma (6,)``, ``Lt (6,6)``, ``statev (nstatev,)``, ``Wm (4,)`` and
+  optionally ``L (6,6)`` (defaults to ``Lt``). Lists, ``float32`` arrays and CPU
+  torch tensors are converted; shapes are checked and a non-finite value is an
+  error.
+* **Finite strain**: under NLGEOM the caller feeds the corotational logarithmic
+  strain and expects the Kirchhoff stress — the same convention as ``ELISO`` /
+  ``EPICP`` (``PYEXT`` belongs to the Kirchhoff-box set). Internal tensorial history
+  is not rotated by the solver; rotate it with ``DR`` in the law if needed.
+
+Step cuts and errors
+--------------------
+
+Raise :class:`simcoon.StepCut` to ask the solver for a smaller increment (the
+trial is discarded and the increment retried; the effective factor is the
+solver's ``div_tnew_dt``). Any other exception aborts the solve and is re-raised
+**unchanged** in Python (type and traceback preserved), including
+``KeyboardInterrupt``. With ``inforce=0`` the solver aborts (``status = 1``, a
+``RuntimeError`` unless ``raise_on_abort=False``) when the increment falls below
+``Dn_mini``; with the default ``inforce=1`` it forces the minimal increment.
+
+Batch entry point and explicit registration
+===========================================
+
+``sim.umat("PYEXT", ...)`` (the per-Gauss-point batch call used by finite-element
+couplers) works with a registered law:
+
+.. code-block:: python
+
+   with sim.registered(law):
+       stress, statev, Wm, Lt = sim.umat("PYEXT", etot, Detot, F0, F1, sigma, DR,
+                                         props, statev, time, dtime, Wm, ndi=3)
+
+The points are integrated **serially** on the calling thread (the callback
+re-enters the interpreter, so it never runs inside the parallel region;
+``n_threads`` is ignored). :func:`simcoon.registered` restores the previously
+registered law on exit; :func:`simcoon.pyumat.register` /
+:func:`simcoon.pyumat.unregister` are the explicit forms.
+
+Performance
+===========
+
+Per call, the bridge acquires the GIL (released by the solver around the C++
+loop), builds small numpy copies of the inputs and copies the outputs back —
+about 5–10 µs, negligible against any non-trivial law. A numpy J2 law costs a few
+tens of µs per call, a small LSTM step with its autograd tangent about a
+millisecond. For finite-element scale, batch the evaluation on the Python side
+(a batched step of its own) rather than calling ``sim.umat``
+point by point.
+
+Examples
+========
+
+* :ref:`sphx_glr_examples_ml_pyumat_numpy_j2.py` — J2 plasticity in numpy
+  compared with ``EPICP``.
+
+API reference
+=============
+
+.. autoclass:: simcoon.PythonUMAT
+   :members:
+
+.. autoclass:: simcoon.StepCut
+
+.. autofunction:: simcoon.registered
+
+.. autofunction:: simcoon.pyumat.register
+
+.. autofunction:: simcoon.pyumat.unregister
+
+.. autofunction:: simcoon.pyumat.current

--- a/docs/simulation/umat_catalog.rst
+++ b/docs/simulation/umat_catalog.rst
@@ -3,7 +3,7 @@ Constitutive model (UMAT) catalog
 ====================================
 
 Every constitutive law is selected by its 5-character ``umat_name``. Since the
-modular UMAT framework, three kinds of implementation coexist behind those
+modular UMAT framework, four kinds of implementation coexist behind those
 names — **the calling convention is identical for all of them** (same
 ``umat_name``, same props, same solver/FEA usage):
 
@@ -19,6 +19,8 @@ names — **the calling convention is identical for all of them** (same
 - **legacy (kept)**: a dedicated, self-contained implementation kept either
   for pedagogy (readable single-file reference of the CCP return mapping) or
   because no modular equivalent exists.
+- **Python (external)**: the ``PYEXT`` name serves a law written in Python
+  (:class:`simcoon.PythonUMAT`) through a registered callback; see :doc:`python_umat`.
 
 Small-strain mechanical models
 ==============================
@@ -148,6 +150,7 @@ Unchanged dedicated implementations (out of the modular scope):
   stretches, props = ``N, kappa, mu_1, alpha_1, ...``).
 - **Multiscale**: MIHEN, MIMTN, MISCN, MIPLN.
 - **Plugins**: UMEXT (external dylib), UMABA (Abaqus wrapper).
+- **Python**: PYEXT (registered Python law; ``props``/``nstatev`` from the object).
 
 State variable (statev) layout for adapter-served names
 ========================================================

--- a/docs/simulation/umat_tutorial.rst
+++ b/docs/simulation/umat_tutorial.rst
@@ -58,6 +58,9 @@ Three contract points that every UMAT must honor:
 3. **cumulative work**: ``Wm += increment`` — the solver reports path
    integrals, never overwrite them.
 
+The same contract applies to a law written in Python and served by the C++
+solver under the ``PYEXT`` name (:doc:`python_umat`): only the language changes.
+
 Step 2 — trial state, typed
 ===========================
 

--- a/examples/ml/README.rst
+++ b/examples/ml/README.rst
@@ -1,0 +1,7 @@
+Python and machine-learning constitutive laws
+-----------------------------------------------
+
+Constitutive laws written in Python and driven by the C++ material-point solver
+through the ``PYEXT`` callback (see :doc:`/simulation/python_umat`).
+
+- **pyumat_numpy_j2** - J2 plasticity written in numpy, compared with ``EPICP``

--- a/examples/ml/pyumat_numpy_j2.py
+++ b/examples/ml/pyumat_numpy_j2.py
@@ -1,0 +1,96 @@
+"""
+J2 plasticity written in Python (PYEXT)
+=======================================
+
+A constitutive law implemented in numpy and integrated by the C++ solver through
+the ``PYEXT`` callback: radial-return J2 plasticity with linear isotropic
+hardening and the consistent (Simo-Hughes) tangent, compared with the built-in
+``EPICP`` kernel (power-law hardening with exponent ``m = 1``).
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import simcoon as sim
+from simcoon.solver import Block, StepMeca, solve
+
+###############################################################################
+# The law
+# -------
+# A :class:`simcoon.PythonUMAT` receives the state at the beginning of the
+# increment (``Etot``, ``sigma``, ``statev``, ``Wm``), the increment ``DEtot`` and
+# returns ``(sigma, Lt, statev, Wm[, L])``. Everything the law must remember lives
+# in ``statev`` (here the cumulated plastic strain ``p`` and the plastic strain
+# tensor): the solver re-calls the same increment during its Newton iterations
+# with ``statev`` reset to its start-of-increment value.
+
+E, NU, SIGMA_Y, K_HARD = 70000.0, 0.3, 300.0, 1000.0
+ENG_SHEAR = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0])   # stress-like -> strain-like Voigt vector
+
+
+class J2Linear(sim.PythonUMAT):
+    nstatev = 7            # p, EP(6)
+
+    def __init__(self, E, nu, sigma_y, k):
+        self.L = sim.L_iso([E, nu], "Enu")
+        self.G = E / (2.0 * (1.0 + nu))
+        self.K = E / (3.0 * (1.0 - 2.0 * nu))
+        self.sigma_y, self.k = sigma_y, k
+        # projectors of the tangent (they act on strain-like vectors)
+        self.Idev = sim.Tensor4.deviatoric("stiffness").mat
+        self.Ivol = sim.Tensor4.volumetric("stiffness").mat
+
+    def integrate(self, *, Etot, DEtot, sigma, statev, Wm, tangent_mode, **kw):
+        p, EP = statev[0], statev[1:7]
+        eps = Etot + DEtot
+        L, G, k = self.L, self.G, self.k
+        sig_tr = L @ (eps - EP)
+        s_tr = sig_tr.copy()
+        s_tr[:3] -= sig_tr[:3].mean()          # stress deviator (not a stiffness projector: it
+                                               # would halve the shear stresses)
+        norm_s = np.sqrt(s_tr[:3] @ s_tr[:3] + 2.0 * (s_tr[3:] @ s_tr[3:]))
+        q_tr = np.sqrt(1.5) * norm_s
+        f = q_tr - (self.sigma_y + k * p)
+        stress, Lt = sig_tr, L
+        if f > 0.0:
+            dp = f / (3.0 * G + k)
+            n = s_tr / norm_s
+            stress = sig_tr - 2.0 * G * dp * np.sqrt(1.5) * n
+            EP = EP + dp * np.sqrt(1.5) * n * ENG_SHEAR
+            p = p + dp
+            if tangent_mode != 0:
+                beta = 1.0 - 3.0 * G * dp / q_tr
+                gamma = 3.0 * G / (3.0 * G + k) - (1.0 - beta)
+                Lt = (3.0 * self.K * self.Ivol + 2.0 * G * beta * self.Idev
+                      - 2.0 * G * gamma * np.outer(n, n * ENG_SHEAR))
+        Wm = Wm.copy()
+        Wm[0] += 0.5 * (sigma + stress) @ DEtot
+        return stress, Lt, np.concatenate([[p], EP]), Wm, L
+
+
+###############################################################################
+# Cyclic uniaxial loading under mixed control
+# --------------------------------------------
+# The axial strain is prescribed, the five other stress components are driven to
+# zero: the tangent returned by the law feeds the Newton loop of the solver.
+
+uniaxial = ["strain"] + ["stress"] * 5
+load = StepMeca(control=uniaxial, value=[0.02, 0, 0, 0, 0, 0], ninc=40)
+reverse = StepMeca(control=uniaxial, value=[-0.02, 0, 0, 0, 0, 0], ninc=40)
+blocks = [Block(steps=[load, reverse], ncycle=2)]
+
+res_py = solve(blocks, J2Linear(E, NU, SIGMA_Y, K_HARD))
+res_ref = solve(blocks, "EPICP", [E, NU, 1.0e-5, SIGMA_Y, K_HARD, 1.0], 8)
+
+print("max |sigma_py - sigma_EPICP| =", np.abs(res_py["Stress"] - res_ref["Stress"]).max(), "MPa")
+print("max |p_py - p_EPICP|         =", np.abs(res_py["Statev"][0] - res_ref["Statev"][1]).max())
+
+fig, ax = plt.subplots(figsize=(6, 4))
+ax.plot(res_ref["Strain"][0], res_ref["Stress"][0], "k-", lw=2, label="EPICP (C++)")
+ax.plot(res_py["Strain"][0], res_py["Stress"][0], "r--", lw=1.5, label="J2 in numpy (PYEXT)")
+ax.set_xlabel(r"$\varepsilon_{11}$")
+ax.set_ylabel(r"$\sigma_{11}$ (MPa)")
+ax.grid(True)
+ax.legend()
+fig.tight_layout()
+plt.show()

--- a/include/simcoon/Continuum_mechanics/Umat/umat_callback.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/umat_callback.hpp
@@ -1,0 +1,100 @@
+/* This file is part of simcoon.
+
+ simcoon is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ simcoon is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with simcoon.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+///@file umat_callback.hpp
+///@brief Process-wide callback slot served by the "PYEXT" UMAT name: a small-strain
+///       constitutive law implemented outside libsimcoon (typically in Python) and
+///       driven by the simcoon solver or by the batch UMAT entry point.
+///@version 2.0
+
+#pragma once
+
+#include <functional>
+#include <string>
+#include <armadillo>
+
+namespace simcoon {
+
+/**
+ * @brief Signature of a small-strain mechanical UMAT (the 24-argument simcoon convention).
+ *
+ * Identical to the built-in kernels (e.g. umat_plasticity_iso_CCP): the callee receives the
+ * strain at the beginning of the increment \f$ \boldsymbol{\varepsilon}_n \f$ (@p Etot), the
+ * increment \f$ \Delta\boldsymbol{\varepsilon} \f$ (@p DEtot), the stress at the beginning of
+ * the increment (@p sigma, in/out), the rotation increment @p DR, the material properties,
+ * the internal variables (@p statev, in/out), the temperature and time data, the accumulated
+ * energies (in/out) and must return the updated stress, the tangent operator
+ * \f$ \mathbf{L}_t = \partial \boldsymbol{\sigma} / \partial \boldsymbol{\varepsilon} \f$
+ * (@p Lt), the elastic operator (@p L), the updated internal variables and energies.
+ *
+ * Voigt order is 11, 22, 33, 12, 13, 23 with engineering shear strains, all quantities
+ * expressed in the material (local) frame. Under finite strain the dispatcher feeds the
+ * logarithmic strain and expects the Kirchhoff stress on output ("PYEXT" belongs to the
+ * kirchhoff_box set of stress_output_is_kirchhoff()), exactly like the built-in small-strain
+ * kernels.
+ *
+ * Contract (see the solver): the callee must be a pure function of its arguments — the solver
+ * restores @p statev, @p sigma and the energies to their start-of-increment values before
+ * every Newton retrial of the same increment. A recurrent model must therefore keep its
+ * hidden state inside @p statev. @p start is true on the first call of a block
+ * (initialise @p statev there). Writing @p tnew_dt < 1 requests a smaller increment.
+ */
+using umat_M_callback = std::function<void(
+    const std::string &umat_name, const arma::vec &Etot, const arma::vec &DEtot,
+    arma::vec &sigma, arma::mat &Lt, arma::mat &L, const arma::mat &DR,
+    const int &nprops, const arma::vec &props, const int &nstatev, arma::vec &statev,
+    const double &T, const double &DT, const double &Time, const double &DTime,
+    double &Wm, double &Wm_r, double &Wm_ir, double &Wm_d,
+    const int &ndi, const int &nshr, const bool &start, double &tnew_dt,
+    const int &tangent_mode)>;
+
+/**
+ * @brief Install the process-wide callback served by the "PYEXT" UMAT name.
+ * @param cb Callable following umat_M_callback. An empty function clears the slot.
+ *
+ * Thread-safe (mutex). The callback itself is invoked outside the lock, serially, by the
+ * solver (one material point) or by the serial branch of the batch UMAT entry point. The
+ * Python bindings register their bridge here; a C++ program may register a plain lambda.
+ */
+void set_umat_callback(umat_M_callback cb);
+
+/// @brief Clear the process-wide callback (subsequent "PYEXT" calls throw exception_solver).
+void clear_umat_callback();
+
+/// @brief True when a callback is installed.
+bool has_umat_callback();
+
+/// @brief Snapshot (copy) of the installed callback; empty when none is installed.
+umat_M_callback get_umat_callback();
+
+/**
+ * @brief UMAT entry point of the "PYEXT" name: forwards the 24-argument call to the installed
+ *        callback.
+ * @throws exception_solver when no callback is installed.
+ *
+ * Has exactly the small-strain UMAT signature so that it can be stored in the same function
+ * pointer as the built-in kernels by the dispatchers.
+ */
+void umat_callback_M(const std::string &umat_name, const arma::vec &Etot, const arma::vec &DEtot,
+                     arma::vec &sigma, arma::mat &Lt, arma::mat &L, const arma::mat &DR,
+                     const int &nprops, const arma::vec &props, const int &nstatev, arma::vec &statev,
+                     const double &T, const double &DT, const double &Time, const double &DTime,
+                     double &Wm, double &Wm_r, double &Wm_ir, double &Wm_d,
+                     const int &ndi, const int &nshr, const bool &start, double &tnew_dt,
+                     const int &tangent_mode);
+
+} // namespace simcoon

--- a/include/simcoon/Simulation/Solver/step.hpp
+++ b/include/simcoon/Simulation/Solver/step.hpp
@@ -138,7 +138,9 @@ protected:
      * @param Dn Increment fraction (output)
      * @param control Increment control flag
      */
-    virtual void compute_inc(double &tnew_dt, const int &inc, double &tinc, double &Dtinc, double &Dn, const int &control);
+    /// @return false when the increment fell below Dn_mini and inforce is off: the solver
+    ///         then aborts with status 1 (same protocol as a non-converged Newton loop).
+    virtual bool compute_inc(double &tnew_dt, const int &inc, double &tinc, double &Dtinc, double &Dn, const int &control);
     
     /**
      * @brief Assignment operator.

--- a/python-setup/simcoon/__init__.py
+++ b/python-setup/simcoon/__init__.py
@@ -15,6 +15,8 @@ from simcoon import modular
 # `import` (not `from ... import`) is required: the latter would return the
 # existing function attribute without importing the subpackage.
 import simcoon.solver
+# Constitutive laws written in Python, served to the C++ solver under 'PYEXT'
+from simcoon.pyumat import PythonUMAT, StepCut, registered
 from simcoon.__version__ import __version__
 from simcoon.rotation import Rotation  # override _CppRotation from star-import
 from simcoon.tensor import Tensor2, Tensor4, dyadic, auto_dyadic, sym_dyadic, auto_sym_dyadic, double_contract  # unified tensor classes

--- a/python-setup/simcoon/doctor.py
+++ b/python-setup/simcoon/doctor.py
@@ -1,0 +1,229 @@
+"""Environment doctor: which OpenMP runtimes does this Python process load?
+
+Run it as ``python -m simcoon.doctor``. It imports, one after the other, numpy,
+scipy, simcoon and (when installed) torch, records the native libraries each
+import brings into the process and reports the OpenMP runtimes found
+(``libomp``, ``libgomp``, ``libiomp5``, ``vcomp``). More than one runtime in a
+process is the classical source of ``OMP: Error #15`` at import and of random
+crashes in threaded kernels; ``KMP_DUPLICATE_LIB_OK=TRUE`` only silences the
+guard.
+
+The rule on macOS and Linux with conda: **one environment = one OpenMP
+runtime**, conda-forge's ``llvm-openmp``. Build simcoon against the
+environment's Armadillo (the default when ``CONDA_PREFIX`` is set) and install
+PyTorch from conda-forge rather than from PyPI wheels (which bundle their own
+``libomp``).
+
+The report is produced in a subprocess started with ``KMP_DUPLICATE_LIB_OK=TRUE``
+so that it survives a duplicate runtime and can describe it.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Dict, List, Optional
+
+# OpenMP runtimes only (not libomptarget / libgomp-plugin-* / libompd helpers)
+_OMP_PATTERN = re.compile(
+    r"^(libomp\d*(\.[a-z0-9_]+)?|libgomp|libiomp5(md)?|vcomp\d*|libvcomp\d*)(-\d+)?(\.\d+)*\.(dylib|so|dll)(\.\d+)*$",
+    re.I)
+# linear-algebra stack, matched on the full path (simcoon's own _core, not any package's)
+_BLAS_PATTERN = re.compile(
+    r"(openblas|libblas|liblapack|mkl_rt|libmkl|Accelerate|armadillo|libsimcoon|[/\\]simcoon[/\\]_core\.)", re.I)
+
+#: Imports probed, in order (missing optional packages are skipped).
+DEFAULT_MODULES = ("numpy", "scipy.linalg", "simcoon", "torch")
+
+
+# ---------------------------------------------------------------------------
+# loaded native images of the current process
+# ---------------------------------------------------------------------------
+
+def loaded_libraries() -> List[str]:
+    """Paths of the native libraries currently loaded in this process."""
+    if sys.platform == "darwin":
+        libsys = ctypes.CDLL("/usr/lib/libSystem.B.dylib")
+        libsys._dyld_image_count.restype = ctypes.c_uint32
+        libsys._dyld_get_image_name.restype = ctypes.c_char_p
+        libsys._dyld_get_image_name.argtypes = [ctypes.c_uint32]
+        n = libsys._dyld_image_count()
+        names = (libsys._dyld_get_image_name(i) for i in range(n))
+        return [p.decode(errors="replace") for p in names if p]     # None if an image vanished
+    if sys.platform.startswith("linux"):
+        paths = set()
+        try:
+            with open("/proc/self/maps") as f:
+                for line in f:
+                    parts = line.rstrip("\n").split(None, 5)        # the path may contain spaces
+                    if len(parts) >= 6 and parts[5].startswith("/"):
+                        paths.add(parts[5])
+        except OSError:
+            pass
+        return sorted(paths)
+    if sys.platform == "win32":
+        from ctypes import wintypes
+        psapi = ctypes.WinDLL("psapi")
+        kernel32 = ctypes.WinDLL("kernel32")
+        kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+        psapi.EnumProcessModulesEx.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.HMODULE),
+                                               wintypes.DWORD, ctypes.POINTER(wintypes.DWORD), wintypes.DWORD]
+        psapi.GetModuleFileNameExW.argtypes = [wintypes.HANDLE, wintypes.HMODULE, wintypes.LPWSTR, wintypes.DWORD]
+        h = kernel32.GetCurrentProcess()
+        mods = (wintypes.HMODULE * 4096)()
+        needed = wintypes.DWORD()
+        if not psapi.EnumProcessModulesEx(h, mods, ctypes.sizeof(mods), ctypes.byref(needed), 0x03):
+            return []
+        count = min(needed.value // ctypes.sizeof(wintypes.HMODULE), 4096)
+        buf = ctypes.create_unicode_buffer(1024)
+        out = []
+        for i in range(count):
+            if psapi.GetModuleFileNameExW(h, mods[i], buf, 1024):
+                out.append(buf.value)
+        return out
+    return []
+
+
+def _probe(modules) -> Dict:
+    """Import the modules one by one and attribute newly loaded libraries to each."""
+    seen = set(loaded_libraries())
+    report = {"python": sys.executable, "platform": sys.platform, "imports": [], "libraries": []}
+    for name in modules:
+        entry = {"module": name, "status": "ok", "new_libraries": []}
+        try:
+            __import__(name)
+        except ImportError as exc:
+            entry["status"] = f"not installed ({exc.__class__.__name__})"
+        except Exception as exc:  # noqa: BLE001 - report anything, the doctor must not die
+            entry["status"] = f"import failed: {exc!r}"
+        now = loaded_libraries()
+        new = [p for p in now if p not in seen]
+        seen.update(new)
+        entry["new_libraries"] = new
+        report["imports"].append(entry)
+    report["libraries"] = sorted(seen)
+    return report
+
+
+def collect(modules=DEFAULT_MODULES) -> Dict:
+    """Run the probe in a fresh subprocess (survives a duplicate OpenMP runtime)."""
+    env = dict(os.environ)
+    env["KMP_DUPLICATE_LIB_OK"] = "TRUE"        # the child must survive the duplicate it reports
+    # Run this file as a script (not `import simcoon.doctor`): importing the simcoon package
+    # would load _core and its BLAS/OpenMP libraries before the probe records its baseline.
+    proc = subprocess.run([sys.executable, os.path.abspath(__file__), "--probe-json", *modules],
+                          capture_output=True, text=True, errors="replace", env=env)
+    # the JSON line is enough even if the child then dies at interpreter teardown
+    report = None
+    for line in reversed(proc.stdout.strip().splitlines()):
+        if line.startswith("{"):
+            try:
+                report = json.loads(line)
+            except ValueError:
+                report = None
+            break
+    if report is None:
+        return {
+            "python": sys.executable, "platform": sys.platform, "imports": [], "libraries": [],
+            "error": f"probe process failed (exit {proc.returncode}): {proc.stderr[-2000:]}",
+        }
+    report["openmp"] = _openmp_runtimes(report)
+    omp_paths = {r["path"] for r in report["openmp"]}
+    report["blas"] = [p for p in report["libraries"] if _BLAS_PATTERN.search(p) and p not in omp_paths]
+    return report
+
+
+def _openmp_runtimes(report: Dict) -> List[Dict]:
+    out = []
+    attributed = set()
+    for entry in report["imports"]:
+        for p in entry["new_libraries"]:
+            if _OMP_PATTERN.search(os.path.basename(p)):
+                out.append({"path": p, "brought_by": entry["module"]})
+                attributed.add(p)
+    # safety net: runtimes present before the first probed import
+    for p in report["libraries"]:
+        if p not in attributed and _OMP_PATTERN.search(os.path.basename(p)):
+            out.append({"path": p, "brought_by": "(loaded before the probe)"})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# human report
+# ---------------------------------------------------------------------------
+
+def _advice(report: Dict) -> List[str]:
+    omp = report.get("openmp", [])
+    tips = []
+    if len(omp) <= 1:
+        return tips
+    conda = os.environ.get("CONDA_PREFIX")
+    for r in omp:
+        p, by = r["path"], r["brought_by"]
+        if by == "torch" and ("site-packages" in p and "torch" in p):
+            tips.append("torch brings its own libomp (PyPI wheel): install PyTorch from conda-forge "
+                        "(`conda install -c conda-forge pytorch`) so it shares the environment's runtime.")
+        elif by == "simcoon" and conda and not p.startswith(conda):
+            tips.append(f"simcoon loads an OpenMP runtime from outside the environment ({p}): rebuild "
+                        "simcoon against the environment's Armadillo (`conda install -c conda-forge "
+                        "armadillo`, delete build/ or build/cp*, then `pip install -e . --no-build-isolation`).")
+        elif conda and not p.startswith(conda):
+            tips.append(f"{by} loads {p}, outside the environment: prefer the conda-forge build of {by}.")
+    tips.append("Do not rely on KMP_DUPLICATE_LIB_OK=TRUE: it hides the error, the crashes remain.")
+    return tips
+
+
+def format_report(report: Dict) -> str:
+    lines = [f"simcoon doctor — {report.get('python')} ({report.get('platform')})"]
+    if "error" in report:
+        lines.append("  " + report["error"])
+        return "\n".join(lines)
+    for entry in report["imports"]:
+        lines.append(f"  import {entry['module']:<14} {entry['status']}")
+    omp = report.get("openmp", [])
+    lines.append("")
+    lines.append(f"OpenMP runtimes loaded: {len(omp)}")
+    for r in omp:
+        lines.append(f"  {r['path']}   (brought by {r['brought_by']})")
+    if report.get("blas"):
+        lines.append("BLAS / linear-algebra libraries:")
+        for p in report["blas"]:
+            lines.append(f"  {p}")
+    lines.append("")
+    if len(omp) <= 1:
+        lines.append("OK: at most one OpenMP runtime in the process.")
+    else:
+        lines.append("PROBLEM: several OpenMP runtimes in one process (OMP Error #15 / random crashes).")
+        for t in _advice(report):
+            lines.append("  - " + t)
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    import argparse
+
+    argv = sys.argv[1:] if argv is None else list(argv)
+    if argv[:1] == ["--probe-json"]:            # child process of collect()
+        print(json.dumps(_probe(tuple(argv[1:]))))
+        return 0
+
+    parser = argparse.ArgumentParser(prog="python -m simcoon.doctor",
+                                     description="Report the OpenMP runtimes loaded by numpy/scipy/simcoon/torch.")
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    parser.add_argument("--modules", nargs="*", default=list(DEFAULT_MODULES),
+                        help="modules to import, in order")
+    args = parser.parse_args(argv)
+    report = collect(args.modules)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(format_report(report))
+    return 0 if len(report.get("openmp", [])) <= 1 and "error" not in report else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python-setup/simcoon/identify.py
+++ b/python-setup/simcoon/identify.py
@@ -118,6 +118,11 @@ def calc_cost(
           (e.g., force in N vs displacement in mm).
         - ``"rmse"`` — Root Mean Squared Error
         - ``"mae"`` — Mean Absolute Error
+        - ``"mape"`` — Mean Absolute Percentage Error (same definition as
+          ``sklearn.metrics.mean_absolute_percentage_error``: ``|y_exp|`` is
+          floored at machine epsilon, so responses crossing zero blow it up —
+          prefer ``"wmape"`` for stress/strain histories)
+        - ``"wmape"`` — weighted MAPE, ``sum(w |y_exp - y_num|) / sum(w |y_exp|)``
 
         With scikit-learn installed (``pip install simcoon[identify]``):
         ``"r2"`` and any ``sklearn.metrics`` function that accepts
@@ -257,6 +262,10 @@ def _nmse_per_response(
     return float(np.mean(nmse_values))
 
 
+#: Metrics computed with numpy only (also the differentiable set of :func:`simcoon.ml.torch_cost`)
+BUILTIN_METRICS = ("mse", "nmse", "nmse_per_response", "rmse", "mae", "mape", "wmape")
+
+
 def _compute_metric(
     y_exp: np.ndarray,
     y_num: np.ndarray,
@@ -280,6 +289,15 @@ def _compute_metric(
 
     if metric == "mae":
         return float(np.average(np.abs(residuals), weights=w))
+
+    if metric == "mape":
+        denom = np.maximum(np.abs(y_exp), np.finfo(np.float64).eps)
+        return float(np.average(np.abs(residuals) / denom, weights=w))
+
+    if metric == "wmape":
+        num = float(np.sum(w * np.abs(residuals)))
+        den = float(np.sum(w * np.abs(y_exp)))
+        return num / den if den > 1e-30 else num
 
     # sklearn metrics
     try:
@@ -306,6 +324,6 @@ def _compute_metric(
         return float(fn(y_exp, y_num, sample_weight=w))
 
     raise ValueError(
-        f"Unknown metric '{metric}'. Built-in: mse, nmse, rmse, mae. "
+        f"Unknown metric '{metric}'. Built-in: {', '.join(BUILTIN_METRICS)}. "
         f"With scikit-learn: r2, mean_squared_error, mean_absolute_error, etc."
     )

--- a/python-setup/simcoon/pyumat.py
+++ b/python-setup/simcoon/pyumat.py
@@ -1,0 +1,220 @@
+"""Constitutive laws written in Python, driven by the C++ solver (UMAT name ``PYEXT``).
+
+A :class:`PythonUMAT` is a point-wise small-strain constitutive law whose
+:meth:`~PythonUMAT.integrate` method is called by the C++ material-point solver
+(:func:`simcoon.solver.solve`) and by the batch entry point ``sim.umat("PYEXT", ...)``
+exactly like a built-in kernel. The C++ side owns the Newton loop, the step
+cutting, the state rollback and the finite-strain kinematics; the Python side
+only integrates one increment at one material point.
+
+Example
+-------
+>>> import numpy as np, simcoon as sim
+>>> class Elastic(sim.PythonUMAT):
+...     nstatev = 0
+...     def __init__(self, E, nu):
+...         self.L = sim.L_iso([E, nu], "Enu")
+...     def integrate(self, *, Etot, DEtot, sigma, statev, Wm, **kw):
+...         stress = self.L @ (Etot + DEtot)
+...         Wm = Wm.copy()
+...         Wm[0] += 0.5 * (sigma + stress) @ DEtot
+...         return stress, self.L, statev, Wm
+>>> step = sim.solver.StepMeca(control=["strain"] + ["stress"] * 5,
+...                            value=[0.01, 0, 0, 0, 0, 0], ninc=20)
+>>> res = sim.solver.solve(step, Elastic(70000., 0.3))
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from abc import ABC, abstractmethod
+from typing import Callable, Optional
+
+import numpy as np
+
+import simcoon._core as _core
+
+#: UMAT name under which the registered Python law is dispatched by the C++ code.
+UMAT_NAME = "PYEXT"
+
+_EMPTY_PROPS = np.zeros(0)
+_EMPTY_PROPS.flags.writeable = False
+
+
+class StepCut(_core.StepCut):
+    """Raise from :meth:`PythonUMAT.integrate` to ask the solver for a smaller increment.
+
+    The current trial is discarded (the solver restores the start-of-increment
+    state) and the increment is retried with a smaller time step.
+
+    Parameters
+    ----------
+    ratio : float
+        Suggested reduction factor in ``(0, 1)``, forwarded as ``tnew_dt``. The material-point
+        solver applies it directly when the cut interrupts a strain-driven increment and
+        replaces it by its own ``div_tnew_dt`` when a Newton loop had to be abandoned.
+    msg : str
+        Message attached to the exception.
+    """
+
+    def __init__(self, ratio: float = 0.5, msg: str = "step cut requested"):
+        super().__init__(msg)
+        self.ratio = float(ratio)
+
+
+class PythonUMAT(ABC):
+    """Point-wise small-strain constitutive law implemented in Python.
+
+    Subclasses set :attr:`nstatev` (number of internal variables), optionally
+    :attr:`props` (material properties forwarded to the C++ material record; may
+    stay empty since the object holds its own parameters) and implement
+    :meth:`integrate`.
+
+    Contract of :meth:`integrate` (identical to the C++ kernels):
+
+    * **stateless between calls** except through ``statev`` and ``Wm``: the solver
+      re-calls the same increment several times (Newton iterations, step cuts) with
+      ``statev``/``sigma``/``Wm`` reset to their start-of-increment values. A
+      recurrent model must keep its hidden state inside ``statev``.
+    * ``start`` is ``True`` on the first call of a block (``Time == 0``): initialise
+      ``statev``/``Wm`` there. ``statev`` arrives zero-filled.
+    * the solver primes the tangent at the start of **every** block with a
+      zero-increment call (``DTime``, ``DT`` and ``DEtot`` all zero), and finite-element
+      couplers do the same at initialisation. That probe is not a step of the loading
+      history: :class:`PythonUMAT` answers it as a pure tangent query (see
+      :meth:`__call__`), so ``integrate`` need not care. A bare callable registered
+      instead of a :class:`PythonUMAT` must handle it itself.
+    * Voigt order ``11 22 33 12 13 23``, **engineering** shear strains, quantities in
+      the material (local) frame. ``Etot`` is the strain at the beginning of the
+      increment, ``DEtot`` the increment, ``sigma`` the stress at the beginning of the
+      increment. Under finite strain the caller feeds the logarithmic strain and
+      expects the Kirchhoff stress (same convention as ELISO/EPICP).
+    * ``ndi`` follows the classical convention: 3 = 3D (plane strain is 3D with a null
+      out-of-plane strain), 2 = plane stress, 1 = uniaxial. ``nshr`` = number of shear
+      components.
+    * ``tangent_mode``: 0 = return the elastic operator as ``Lt``, 1 = continuum
+      tangent, 2 = algorithmic (consistent) tangent.
+    * ``Wm`` is the accumulated ``(Wm, Wm_r, Wm_ir, Wm_d)`` at the beginning of the
+      increment and must be returned accumulated.
+    * returns ``(sigma (6,), Lt (6,6), statev (nstatev,), Wm (4,)[, L (6,6)])`` as
+      float arrays (lists / float32 / CPU torch tensors are converted). ``L`` defaults
+      to ``Lt``. Raise :class:`StepCut` to request a smaller increment; any other
+      exception aborts the solve and is re-raised unchanged.
+    """
+
+    #: Material properties forwarded to the C++ material record (floats). May be empty.
+    #: The default is a shared read-only array: a law with properties assigns its own
+    #: (``self.props = np.array([...])``) rather than mutating this one in place.
+    props: np.ndarray = _EMPTY_PROPS
+    #: Number of internal state variables.
+    nstatev: int = 0
+
+    @abstractmethod
+    def integrate(
+        self,
+        *,
+        Etot: np.ndarray,
+        DEtot: np.ndarray,
+        sigma: np.ndarray,
+        DR: np.ndarray,
+        props: np.ndarray,
+        statev: np.ndarray,
+        T: float,
+        DT: float,
+        Time: float,
+        DTime: float,
+        Wm: np.ndarray,
+        ndi: int,
+        nshr: int,
+        start: bool,
+        tangent_mode: int,
+        **_,
+    ):
+        """Integrate one increment at one material point (see class docstring)."""
+
+    def __call__(self, **kwargs):
+        """Entry point used by the C++ bridge: :meth:`integrate`, except that the
+        zero-increment tangent probe (``DTime == 0`` and ``DEtot == 0``) is a pure tangent
+        query: stress, ``statev`` and ``Wm`` are returned exactly as received (a zero
+        increment changes none of them), only ``Lt``/``L`` come from the evaluation."""
+        probe = (float(kwargs["DTime"]) == 0.0 and float(kwargs["DT"]) == 0.0
+                 and not np.any(kwargs["DEtot"]))
+        if not probe:
+            return self.integrate(**kwargs)
+        # copies first: a law updating its inputs in place must not leak the probe
+        sigma0 = np.array(kwargs["sigma"], dtype=float, copy=True)
+        statev0 = np.array(kwargs["statev"], dtype=float, copy=True)
+        Wm0 = np.array(kwargs["Wm"], dtype=float, copy=True)
+        out = self.integrate(**kwargs)
+        return (sigma0, out[1], statev0, Wm0, *out[4:])
+
+
+_current: Optional[object] = None
+_owner: Optional[int] = None
+
+
+def current():
+    """Return the currently registered Python law (or ``None``)."""
+    return _current
+
+
+def _as_callable(umat) -> Callable:
+    if callable(umat):                  # PythonUMAT instances are callable (probe rule inside)
+        return umat
+    raise TypeError(
+        "expected a PythonUMAT instance or a callable with the integrate() keyword "
+        f"signature, got {type(umat).__name__}"
+    )
+
+
+def register(umat) -> None:
+    """Register ``umat`` as the process-wide ``PYEXT`` law (prefer :func:`registered`).
+
+    The slot is process-wide: registering from a second thread while another thread's
+    law is in place raises instead of silently rebinding that thread's running solve.
+    """
+    global _current, _owner
+    me = threading.get_ident()
+    if _current is not None and _owner != me and _owner in {t.ident for t in threading.enumerate()}:
+        raise RuntimeError("a Python UMAT is already registered by another live thread "
+                           "(PYEXT serves one law per process)")
+    _core.register_python_umat(_as_callable(umat))
+    _current, _owner = umat, me
+
+
+def unregister() -> None:
+    """Remove the process-wide ``PYEXT`` law (only the registering thread may do so while
+    it is alive: a solve running on that thread must not lose its law)."""
+    global _current, _owner
+    me = threading.get_ident()
+    if _current is not None and _owner != me and _owner in {t.ident for t in threading.enumerate()}:
+        raise RuntimeError("the Python UMAT was registered by another live thread")
+    _core.unregister_python_umat()
+    _current, _owner = None, None
+
+
+@contextlib.contextmanager
+def registered(umat):
+    """Context manager: register ``umat`` for the block, restore the previous law on exit.
+
+    Parameters
+    ----------
+    umat : PythonUMAT or callable
+        The law to serve under the ``PYEXT`` name.
+    """
+    previous = _current
+    register(umat)
+    try:
+        yield umat
+    finally:
+        if previous is None:
+            unregister()
+        else:
+            register(previous)
+
+
+__all__ = [
+    "UMAT_NAME", "PythonUMAT", "StepCut", "registered", "register", "unregister",
+    "current",
+]

--- a/python-setup/simcoon/solver/core.py
+++ b/python-setup/simcoon/solver/core.py
@@ -2,22 +2,24 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, Sequence, Union
+import contextlib
+from typing import Any, Callable, Optional, Sequence, Union
 
 import numpy as np
 
 import simcoon._core as _core
+from simcoon.pyumat import UMAT_NAME, registered
 
-from .blocks import Block, StepMeca
+from .blocks import Block, StepMeca, StepThermomeca
 from .maps import CORATE_TYPES, TANGENT_MODES, as_code, tangent_default
 from .results import SolverResults
 
 
 def solve(
     blocks: Union[Block, StepMeca, Sequence[Union[Block, StepMeca]]],
-    umat_name: str,
-    props: Sequence[float],
-    nstatev: int,
+    umat_name: Union[str, Any, Callable],
+    props: Optional[Sequence[float]] = None,
+    nstatev: Optional[int] = None,
     T_init: float = 293.15,
     corate: Union[str, int, None] = None,
     tangent_mode: Union[str, int] = tangent_default,
@@ -33,12 +35,19 @@ def solve(
     ----------
     blocks : Block, StepMeca or sequence of them
         The loading path. Bare steps are wrapped in a small-strain Block.
-    umat_name : str
-        Constitutive model name (5 characters, e.g. 'ELISO', 'EPICP', 'MODUL').
-    props : array-like
-        Material properties.
-    nstatev : int
-        Number of internal state variables.
+    umat_name : str, PythonUMAT or callable
+        Constitutive model: either the name of a built-in model (5 characters,
+        e.g. 'ELISO', 'EPICP', 'MODUL') or a constitutive law written in Python
+        (a :class:`simcoon.PythonUMAT` instance, or any callable with its
+        ``integrate`` keyword signature). A Python law is registered under the
+        ``PYEXT`` name for the duration of the call and integrated by the C++
+        solver exactly like a built-in kernel.
+    props : array-like, optional
+        Material properties. Required for a built-in model; defaults to the
+        ``props`` attribute of a Python law.
+    nstatev : int, optional
+        Number of internal state variables. Required for a built-in model;
+        defaults to the ``nstatev`` attribute of a Python law.
     T_init : float
         Initial temperature.
     corate : str, int or None
@@ -60,7 +69,9 @@ def solve(
         thermomechanical tangents).
     raise_on_abort : bool
         Raise a RuntimeError when the solver aborts early (status != 0)
-        instead of returning the partial history.
+        instead of returning the partial history. The solver aborts when the
+        Newton loop does not converge at the minimal increment, or when the
+        increment falls below ``Dn_mini`` with ``inforce=0``.
     **params
         Numeric solver controls forwarded to the C++ loop: div_tnew_dt,
         mul_tnew_dt, miniter, maxiter, inforce, precision, lambda_solver
@@ -75,6 +86,30 @@ def solve(
         blocks = [blocks]
     blocks = [b if isinstance(b, Block) else Block(steps=[b]) for b in blocks]
 
+    if isinstance(umat_name, str):
+        if props is None or nstatev is None:
+            raise TypeError(
+                "props and nstatev are required when umat_name is a built-in model name"
+            )
+        law_ctx = contextlib.nullcontext()
+    else:
+        # Python law: served under PYEXT for the duration of the solve. The thermomechanical
+        # dispatch (select_umat_T) has no PYEXT entry, so reject those blocks here with a clear
+        # message instead of a C++ "Unknown umat name" from deep inside the solve.
+        for b in blocks:
+            if any(isinstance(st, StepThermomeca) for st in b.steps):
+                raise TypeError(
+                    "a constitutive law written in Python (PYEXT) cannot serve a thermomechanical "
+                    "block: only the mechanical dispatch supports it. Use a built-in "
+                    "thermomechanical UMAT name, or drive the coupling from Python."
+                )
+        if props is None:
+            props = getattr(umat_name, "props", np.zeros(0))
+        if nstatev is None:
+            nstatev = getattr(umat_name, "nstatev", 0)
+        law_ctx = registered(umat_name)
+        umat_name = UMAT_NAME
+
     if corate is None:
         corate = "logarithmic_R"
     corate_code = as_code(corate, CORATE_TYPES, "corate")
@@ -88,18 +123,19 @@ def solve(
         T_run = b.T_end(T_run)
 
     psi, theta, phi = (float(x) for x in orientation)
-    raw = _core.solver_run(
-        blocks_py,
-        float(T_init),
-        umat_name,
-        np.asarray(props, dtype=float).ravel(),
-        int(nstatev),
-        psi, theta, phi,
-        int(solver_type),
-        corate_code,
-        run_params,
-        bool(record_tangent),
-    )
+    with law_ctx:
+        raw = _core.solver_run(
+            blocks_py,
+            float(T_init),
+            umat_name,
+            np.asarray(props, dtype=float).ravel(),
+            int(nstatev),
+            psi, theta, phi,
+            int(solver_type),
+            corate_code,
+            run_params,
+            bool(record_tangent),
+        )
     res = SolverResults(raw)
     if raise_on_abort and res.status != 0:
         raise RuntimeError(

--- a/simcoon-python-builder/CMakeLists.txt
+++ b/simcoon-python-builder/CMakeLists.txt
@@ -36,6 +36,7 @@ pybind11_add_module(_core
   src/python_wrappers/Libraries/Continuum_mechanics/tensor.cpp
   src/python_wrappers/Libraries/Continuum_mechanics/transfer.cpp
   src/python_wrappers/Libraries/Continuum_mechanics/umat.cpp
+  src/python_wrappers/Libraries/Continuum_mechanics/pyumat.cpp
 
   # Homogenization
   src/python_wrappers/Libraries/Homogenization/eshelby.cpp

--- a/simcoon-python-builder/include/simcoon/python_wrappers/Libraries/Continuum_mechanics/pyumat.hpp
+++ b/simcoon-python-builder/include/simcoon/python_wrappers/Libraries/Continuum_mechanics/pyumat.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include <pybind11/pybind11.h>
+
+namespace simpy {
+
+/// @brief Bind the Python-callback UMAT ("PYEXT") machinery on module `m`:
+///        the `StepCut` exception type, `register_python_umat(fn)`,
+///        `unregister_python_umat()` and `has_python_umat()`.
+///
+/// The registered Python callable is invoked, with the GIL acquired, by the
+/// C++ dispatchers through simcoon::umat_callback_M. Call once from PYBIND11_MODULE.
+void init_pyumat(pybind11::module_ &m);
+
+} // namespace simpy

--- a/simcoon-python-builder/src/python_wrappers/Libraries/Continuum_mechanics/pyumat.cpp
+++ b/simcoon-python-builder/src/python_wrappers/Libraries/Continuum_mechanics/pyumat.cpp
@@ -1,0 +1,248 @@
+/* This file is part of simcoon.
+
+ simcoon is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ simcoon is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with simcoon.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+///@file pyumat.cpp
+///@brief Bridge between the C++ "PYEXT" callback slot (umat_callback.hpp) and a Python
+///       callable: numpy marshalling, GIL handling, StepCut and error propagation.
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/gil_safe_call_once.h>
+
+#include <algorithm>
+#include <cstring>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <carma>
+#include <armadillo>
+
+#include <simcoon/exception.hpp>
+#include <simcoon/Continuum_mechanics/Umat/umat_callback.hpp>
+#include <simcoon/python_wrappers/Libraries/Continuum_mechanics/pyumat.hpp>
+
+namespace py = pybind11;
+using namespace pybind11::literals;
+
+namespace simpy {
+
+namespace {
+
+struct step_cut_tag {};
+
+// Module-lifetime Python objects. Neither is ever destroyed: a static py::object destructor
+// running at interpreter teardown (after Py_Finalize) is a documented pybind11 crash. The
+// exception type uses the gil_safe_call_once_and_store idiom; the callable lives in a
+// heap slot that is intentionally leaked (unregister assigns None to release the user object).
+PYBIND11_CONSTINIT static py::gil_safe_call_once_and_store<py::object> g_step_cut;
+static py::object *g_fn = nullptr;   // touched only with the GIL held
+
+using farr = py::array_t<double, py::array::f_style | py::array::forcecast>;
+
+// (rows, cols) column-major copy — cheaper than carma::mat_to_arr(arma::mat(m)), which
+// heap-allocates an arma copy plus a capsule for the 9 doubles of DR on every call
+farr np2d(const arma::mat &m) {
+    farr a({static_cast<py::ssize_t>(m.n_rows), static_cast<py::ssize_t>(m.n_cols)});
+    if (m.n_elem > 0) {
+        std::memcpy(a.mutable_data(), m.memptr(), m.n_elem * sizeof(double));
+    }
+    return a;
+}
+
+// (n,) copy — carma::col_to_arr would give (n,1)
+py::array_t<double> np1d(const arma::vec &v) {
+    py::array_t<double> a(static_cast<py::ssize_t>(v.n_elem));
+    if (v.n_elem > 0) {
+        std::memcpy(a.mutable_data(), v.memptr(), v.n_elem * sizeof(double));
+    }
+    return a;
+}
+
+std::string shape_str(const std::vector<py::ssize_t> &shape) {
+    std::ostringstream os;
+    os << "(";
+    for (size_t i = 0; i < shape.size(); i++) {
+        if (i > 0) os << ", ";
+        os << shape[i];
+    }
+    os << (shape.size() == 1 ? ",)" : ")");
+    return os.str();
+}
+
+std::string shape_str(const farr &a) {
+    std::vector<py::ssize_t> s(a.ndim());
+    for (py::ssize_t k = 0; k < a.ndim(); k++) s[k] = a.shape(k);
+    return shape_str(s);
+}
+
+// Normalise one returned value to a float64 Fortran-ordered array of the expected shape.
+// Accepts anything numpy can convert (list, float32, CPU torch tensor via __array__).
+farr take(py::handle obj, const char *what, const std::vector<py::ssize_t> &shape) {
+    farr a = farr::ensure(obj);
+    if (!a) {
+        throw py::type_error(std::string("PYEXT: returned '") + what +
+                             "' is not convertible to a float64 array (return numpy arrays; "
+                             "for torch tensors use .detach().cpu().numpy())");
+    }
+    bool ok = (a.ndim() == static_cast<py::ssize_t>(shape.size()));
+    for (size_t k = 0; ok && k < shape.size(); k++) {
+        ok = (a.shape(static_cast<py::ssize_t>(k)) == shape[k]);
+    }
+    if (!ok) {
+        throw py::value_error(std::string("PYEXT: returned '") + what + "' must have shape " +
+                              shape_str(shape) + ", got " + shape_str(a));
+    }
+    return a;
+}
+
+void python_umat_bridge(const std::string &umat_name, const arma::vec &Etot, const arma::vec &DEtot,
+                        arma::vec &sigma, arma::mat &Lt, arma::mat &L, const arma::mat &DR,
+                        const int &nprops, const arma::vec &props, const int &nstatev, arma::vec &statev,
+                        const double &T, const double &DT, const double &Time, const double &DTime,
+                        double &Wm, double &Wm_r, double &Wm_ir, double &Wm_d,
+                        const int &ndi, const int &nshr, const bool &start, double &tnew_dt,
+                        const int &tangent_mode)
+{
+    (void)umat_name;
+    (void)nprops;
+    // Re-entrant on the calling thread: a no-op when the GIL is already held (batch path),
+    // an acquire when the solver released it (solver_run).
+    py::gil_scoped_acquire gil;
+
+    if (!g_fn || g_fn->is_none()) {
+        throw simcoon::exception_solver("PYEXT: no Python UMAT registered");
+    }
+
+    py::array_t<double> Wm4(4);
+    {
+        double *w = Wm4.mutable_data();
+        w[0] = Wm; w[1] = Wm_r; w[2] = Wm_ir; w[3] = Wm_d;
+    }
+    py::object ret;
+    try {
+        ret = (*g_fn)("Etot"_a = np1d(Etot), "DEtot"_a = np1d(DEtot), "sigma"_a = np1d(sigma),
+                      "DR"_a = np2d(DR), "props"_a = np1d(props),
+                      "statev"_a = np1d(statev),
+                      "T"_a = T, "DT"_a = DT, "Time"_a = Time, "DTime"_a = DTime,
+                      "Wm"_a = Wm4, "ndi"_a = ndi, "nshr"_a = nshr, "start"_a = start,
+                      "tangent_mode"_a = tangent_mode);
+    } catch (py::error_already_set &e) {
+        if (e.matches(g_step_cut.get_stored())) {
+            // Requested step cut: leave sigma/statev/Wm untouched (the solver restores the
+            // start-of-increment state before retrying); it only tests tnew_dt < 1.
+            double ratio = 0.5;
+            try {
+                ratio = e.value().attr("ratio").cast<double>();
+            } catch (...) {
+            }
+            tnew_dt = std::min(std::max(ratio, 1.e-3), 0.99);
+            return;
+        }
+        // Propagate the ORIGINAL Python exception unchanged: never inspect it here
+        // (what() needs the GIL); the pybind11 dispatcher restores it on the way out.
+        throw;
+    }
+
+    if (!(py::isinstance<py::tuple>(ret) || py::isinstance<py::list>(ret))) {
+        throw py::type_error("PYEXT: integrate() must return a tuple "
+                             "(sigma, Lt, statev, Wm[, L])");
+    }
+    py::sequence out = py::reinterpret_borrow<py::sequence>(ret);
+    const py::ssize_t n = static_cast<py::ssize_t>(py::len(out));
+    if (n != 4 && n != 5) {
+        throw py::value_error("PYEXT: expected 4 or 5 return values (sigma, Lt, statev, Wm[, L]), got "
+                              + std::to_string(n));
+    }
+    farr s = take(out[0], "sigma", {6});
+    farr lt = take(out[1], "Lt", {6, 6});
+    farr sv = take(out[2], "statev", {static_cast<py::ssize_t>(nstatev)});
+    farr wm = take(out[3], "Wm", {4});
+
+    // Build locals first (f_style => column-major, so mat(ptr, 6, 6) reads the returned layout
+    // as is), validate, and only then commit: sigma/Lt/statev/Wm* alias the caller's live state,
+    // so a throw after a partial assignment would leave it corrupted.
+    const arma::vec sigma_new(s.data(), 6);
+    const arma::mat Lt_new(lt.data(), 6, 6);
+    const arma::vec statev_new(sv.data(), static_cast<arma::uword>(std::max(nstatev, 0)));
+    const arma::vec Wm_new(wm.data(), 4);
+    arma::mat L_new;
+    if (n == 5) {
+        farr l = take(out[4], "L", {6, 6});
+        L_new = arma::mat(l.data(), 6, 6);
+    } else {
+        L_new = Lt_new;
+    }
+    if (!sigma_new.is_finite() || !Lt_new.is_finite() || !statev_new.is_finite()
+            || !Wm_new.is_finite() || !L_new.is_finite()) {
+        throw py::value_error(
+            "PYEXT: non-finite value in the returned sigma/Lt/statev/Wm/L (the state was left "
+            "untouched). Raise simcoon.StepCut instead to ask the material-point solver for a "
+            "smaller increment.");
+    }
+    sigma = sigma_new;
+    Lt = Lt_new;
+    if (nstatev > 0) {
+        statev = statev_new;
+    }
+    Wm = Wm_new(0);
+    Wm_r = Wm_new(1);
+    Wm_ir = Wm_new(2);
+    Wm_d = Wm_new(3);
+    L = L_new;
+}
+
+} // namespace
+
+void init_pyumat(py::module_ &m)
+{
+    py::object step_cut = py::exception<step_cut_tag>(m, "StepCut", PyExc_RuntimeError);
+    step_cut.attr("__doc__") = "Raised by a Python UMAT to request a smaller increment "
+                               "(see simcoon.pyumat.StepCut).";
+    g_step_cut.call_once_and_store_result([&]() { return step_cut; });
+
+    m.def("register_python_umat", [](py::object fn) {
+        if (!PyCallable_Check(fn.ptr())) {
+            throw py::type_error("register_python_umat: object is not callable");
+        }
+        if (!g_fn) g_fn = new py::object();
+        *g_fn = std::move(fn);
+        // Plain function pointer: no Python object is captured in the C++ std::function.
+        simcoon::set_umat_callback(&python_umat_bridge);
+    }, "fn"_a,
+    "Register the Python callable served under the 'PYEXT' UMAT name (keyword call: "
+    "Etot, DEtot, sigma, DR, props, statev, T, DT, Time, DTime, Wm, ndi, nshr, start, "
+    "tangent_mode -> (sigma, Lt, statev, Wm[, L])). Prefer simcoon.registered().");
+
+    m.def("unregister_python_umat", []() {
+        simcoon::clear_umat_callback();
+        if (g_fn) *g_fn = py::none();   // release the user object now, keep the slot
+    }, "Remove the Python UMAT served under 'PYEXT'.");
+
+    m.def("has_python_umat", []() {
+        return g_fn && !g_fn->is_none() && simcoon::has_umat_callback();
+    }, "True when a Python UMAT is registered under 'PYEXT'.");
+
+    // Module teardown (GIL held, interpreter alive): drop the user object (e.g. a torch
+    // model) deterministically. Correctness does not depend on this.
+    m.add_object("_pyumat_cleanup", py::capsule([]() {
+        simcoon::clear_umat_callback();
+        if (g_fn) *g_fn = py::none();
+    }));
+}
+
+} // namespace simpy

--- a/simcoon-python-builder/src/python_wrappers/Libraries/Continuum_mechanics/umat.cpp
+++ b/simcoon-python-builder/src/python_wrappers/Libraries/Continuum_mechanics/umat.cpp
@@ -12,6 +12,7 @@
 #include <simcoon/python_wrappers/Libraries/Continuum_mechanics/umat.hpp>
 
 #include <simcoon/Continuum_mechanics/Umat/umat_smart.hpp>
+#include <simcoon/Continuum_mechanics/Umat/umat_callback.hpp>
 #include <simcoon/Continuum_mechanics/Umat/Mechanical/External/external_umat.hpp>
 #include <simcoon/Continuum_mechanics/Umat/Mechanical/Plasticity/plastic_isotropic_ccp.hpp>
 #include <simcoon/Continuum_mechanics/Umat/Mechanical/Plasticity/plastic_chaboche_ccp.hpp>
@@ -72,7 +73,7 @@ namespace simpy {
 			throw std::invalid_argument("tangent_mode must be 0 (none), 1 (continuum) or 2 (algorithmic); got "
 			                            + std::to_string(tangent_mode) + " (3 = closest-point is reserved)");
 		}
-		static const std::map<string, int> list_umat = { {"UMEXT",0},{"UMABA",1},{"ELISO",201},{"ELIST",201},{"ELORT",201},{"EPICP",5},{"EPKCP",201},{"EPCHA",7},{"EPHIL",201},{"EPTRI",201},{"EPHAC",201},{"EPANI",201},{"EPDFA",201},{"EPHIN",201},{"SMADI",13},{"SMADC",13},{"SMAAI",13},{"SMAAC",13},{"LLDM0",15},{"ZENER",16},{"ZENNK",17},{"PRONK",18},{"SMAMO",19},{"SMAMC",20},{"NEOHC",21},{"MOORI",22},{"YEOHH",23},{"ISHAH",24},{"GETHH",25},{"SWANH",26},{"EPCHG",201},{"SMRDI",28},{"SMRDC",28},{"SMRAI",28},{"SMRAC",28},{"SNTVE",29},{"NEOHI",30},{"OGDEN",31},{"HYPOO",32},{"MODUL",200},{"MIHEN",100},{"MIMTN",101},{"MISCN",103},{"MIPLN",104} };
+		static const std::map<string, int> list_umat = { {"UMEXT",0},{"UMABA",1},{"ELISO",201},{"ELIST",201},{"ELORT",201},{"EPICP",5},{"EPKCP",201},{"EPCHA",7},{"EPHIL",201},{"EPTRI",201},{"EPHAC",201},{"EPANI",201},{"EPDFA",201},{"EPHIN",201},{"SMADI",13},{"SMADC",13},{"SMAAI",13},{"SMAAC",13},{"LLDM0",15},{"ZENER",16},{"ZENNK",17},{"PRONK",18},{"SMAMO",19},{"SMAMC",20},{"NEOHC",21},{"MOORI",22},{"YEOHH",23},{"ISHAH",24},{"GETHH",25},{"SWANH",26},{"EPCHG",201},{"SMRDI",28},{"SMRDC",28},{"SMRAI",28},{"SMRAC",28},{"SNTVE",29},{"NEOHI",30},{"OGDEN",31},{"HYPOO",32},{"MODUL",200},{"MIHEN",100},{"MIMTN",101},{"MISCN",103},{"MIPLN",104},{"PYEXT",300} };
 		// guarded lookup (serial context): operator[] would default-insert
 		// 0 = UMEXT, silently routing typos to the external-plugin path
 		const auto it_umat = list_umat.find(umat_name_py);
@@ -81,6 +82,9 @@ namespace simpy {
 		}
 		const int id_umat = it_umat->second;
 		int arguments_type; //depends on the argument used in the umat
+		// PYEXT (Python callback law) re-enters the interpreter: it must run on the calling
+		// thread, never inside the GCD/OpenMP region (parallel.hpp contract).
+		const bool serial = (id_umat == 300);
 
 		// Unified small-strain function pointer: (umat_name, Etot, DEtot, sigma, Lt, L, DR, nprops, props, nstatev, statev, T, DT, Time, DTime, Wm, Wm_r, Wm_ir, Wm_d, ndi, nshr, start, tnew_dt, tangent_mode)
 		void (*umat_function)(const std::string &, const arma::vec &, const arma::vec &, arma::vec &, arma::mat &, arma::mat &, const arma::mat &, const int &, const arma::vec &, const int &, arma::vec &, const double &, const double &, const double &, const double &, double &, double &, double &, double &, const int &, const int &, const bool &, double &, const int &);
@@ -104,7 +108,11 @@ namespace simpy {
 			start = false;
 		}
 
-		double tnew_dt = 0;//usefull ?		
+		// Step-cut request of the kernels. Each point writes its OWN local (the kernels take
+		// `double &`), so the parallel branch has no shared write; only the serial PYEXT branch
+		// publishes it here, and only that branch inspects it. The documented contract for the
+		// built-in kernels is that a direct caller subdivides the increment itself.
+		double tnew_dt = 1.;
 		//bool use_temp;
 		//if (T.n_elem == 0.) use_temp = false; 
 		//else use_temp = true;
@@ -126,15 +134,28 @@ namespace simpy {
 		cube DR = carma::arr_to_cube_view(DR_py); 
 		cube F0, F1;
 
+		// props: (nprops, 1) or a 1-D (nprops,) vector = shared by all points; (nprops, n) = per point.
+		// (a 1-D array has no shape[1]: reading it was undefined behaviour and fed garbage props
+		// to every point after the first)
 		vec props;
-		mat list_props = carma::arr_to_mat_view(props_py);
-		auto shape = props_py.shape();
-
+		mat list_props;
 		bool unique_props = false;
-		if (shape[1] == 1) {
-			props = list_props.col(0);
+		if (props_py.ndim() == 1) {
+			props = carma::arr_to_col(props_py);
+			list_props = mat(props.memptr(), props.n_elem, 1, false, true);
 			unique_props = true;
-		}		
+		} else {
+			if (props_py.ndim() != 2) {
+				throw std::invalid_argument("umat: props must be a (nprops,) vector or a (nprops, 1 | n_points) array");
+			}
+			list_props = carma::arr_to_mat_view(props_py);
+			if (props_py.shape(1) == 1) {
+				props = list_props.col(0);
+				unique_props = true;
+			} else if (props_py.shape(1) != nb_points) {
+				throw std::invalid_argument("umat: props must have one column, or one column per material point");
+			}
+		}
 
 		mat list_statev = carma::arr_to_mat(std::move(statev_py)); //copy data because values are changed by the umat and returned to python
 		mat list_Wm = carma::arr_to_mat(std::move(Wm_py)); //copy data because values are changed by the umat and returned to python
@@ -238,6 +259,13 @@ namespace simpy {
 				arguments_type = 2;
 				break;
 			}
+			case 300: {
+				// PYEXT: process-wide callback UMAT (umat_callback.hpp), i.e. a Python law.
+				// It re-enters the interpreter, so it runs serially on the calling thread.
+				umat_function = &simcoon::umat_callback_M;
+				arguments_type = 1;
+				break;
+			}
 			default: {
 				throw std::invalid_argument( "The choice of Umat could not be found in the umat library." );
 			}
@@ -266,7 +294,7 @@ namespace simpy {
 			kirchhoff_normalize = true;
 		}
 
-		simcoon_parallel_for_safe(nb_points, [&](int pt) {
+		auto point_kernel = [&](int pt) {
 			// Alias the props column without copying so the parallel region makes no
 			// NumPy-backed (carma) allocation: GCD/OpenMP workers then never call
 			// PyDataMem_NEW (which needs the GIL) -> no GIL deadlock, no GIL handling.
@@ -284,6 +312,7 @@ namespace simpy {
 			if (use_temp && pt < vec_T.n_elem) {
 				T = vec_T(pt);
 			}
+			double tnew_dt_pt = 1.;   // per-point: no shared write inside the parallel region
 
 			if (kirchhoff_normalize) {
 				// python contract stress (Cauchy) -> kernel internal
@@ -297,14 +326,15 @@ namespace simpy {
 			}
 			switch (arguments_type) {
 				case 1: {
-					umat_function(umat_name_py, etot, Detot, sigma, Lt.slice(pt), L.slice(pt), DR.slice(pt), nprops, local_props, nstatev, statev, T, DT, Time, DTime, Wm(0), Wm(1), Wm(2), Wm(3), ndi, nshr, start, tnew_dt, tangent_mode);
+					umat_function(umat_name_py, etot, Detot, sigma, Lt.slice(pt), L.slice(pt), DR.slice(pt), nprops, local_props, nstatev, statev, T, DT, Time, DTime, Wm(0), Wm(1), Wm(2), Wm(3), ndi, nshr, start, tnew_dt_pt, tangent_mode);
 					break;
 				}
 				case 2: {
-					umat_function_finite(umat_name_py, etot, Detot, F0.slice(pt), F1.slice(pt), sigma, Lt.slice(pt), L.slice(pt), DR.slice(pt), nprops, local_props, nstatev, statev, T, DT, Time, DTime, Wm(0), Wm(1), Wm(2), Wm(3), ndi, nshr, start, tnew_dt, tangent_mode);
+					umat_function_finite(umat_name_py, etot, Detot, F0.slice(pt), F1.slice(pt), sigma, Lt.slice(pt), L.slice(pt), DR.slice(pt), nprops, local_props, nstatev, statev, T, DT, Time, DTime, Wm(0), Wm(1), Wm(2), Wm(3), ndi, nshr, start, tnew_dt_pt, tangent_mode);
 					break;
 				}
 			}
+			if (serial) tnew_dt = tnew_dt_pt;   // single thread: safe to publish
 			if (kirchhoff_normalize) {
 				// kernel internal (Kirchhoff) -> python contract (Cauchy);
 				// Lt is deliberately NOT rescaled (see the block above).
@@ -312,7 +342,27 @@ namespace simpy {
 				const double J1 = arma::det(F1.slice(pt));
 				if (J1 > simcoon::iota) sigma /= J1;
 			}
-		});
+		};
+		if (serial) {
+			// PYEXT calls back into Python: it must stay on the calling thread (which holds the
+			// GIL, so the gil_scoped_acquire in the bridge is a no-op). A plain loop, not
+			// simcoon_parallel_for_safe with a large cutoff: the OpenMP build of the helper
+			// captures the exception of a failing point and keeps calling the law for all the
+			// remaining ones, which the GCD build does not — here the first error must stop
+			// the batch on every platform.
+			for (int pt = 0; pt < nb_points; pt++) {
+				point_kernel(pt);
+				if (tnew_dt < 1.) {
+					throw std::runtime_error(
+						"umat: the law requested a step cut (simcoon.StepCut) at material point "
+						+ std::to_string(pt) + ", but the batch entry point cannot subdivide the "
+						"increment: catch it in the caller and re-run that point with a smaller "
+						"increment (the material-point solver handles it automatically).");
+				}
+			}
+		} else {
+			simcoon_parallel_for_safe(nb_points, point_kernel);
+		}
 		return py::make_tuple(carma::mat_to_arr(list_sigma, false), carma::mat_to_arr(list_statev, false), carma::mat_to_arr(list_Wm, false), carma::cube_to_arr(Lt, false));
 
 	}

--- a/simcoon-python-builder/src/python_wrappers/python_module.cpp
+++ b/simcoon-python-builder/src/python_wrappers/python_module.cpp
@@ -18,6 +18,7 @@
 #include <simcoon/python_wrappers/Libraries/Continuum_mechanics/kinematics.hpp>
 #include <simcoon/python_wrappers/Libraries/Continuum_mechanics/objective_rates.hpp>
 #include <simcoon/python_wrappers/Libraries/Continuum_mechanics/umat.hpp>
+#include <simcoon/python_wrappers/Libraries/Continuum_mechanics/pyumat.hpp>
 // #include <simcoon/python_wrappers/Libraries/Continuum_mechanics/RunUmat.hpp>
 
 #include <simcoon/python_wrappers/Libraries/Continuum_mechanics/tensor.hpp>
@@ -69,6 +70,9 @@ PYBIND11_MODULE(_core, m)
     py::register_exception<simcoon::exception_expmat_sym>(m, "CppExceptionExpMatSym", SimcoonError.ptr());
     py::register_exception<simcoon::exception_powmat>(m, "CppExceptionPowMat", SimcoonError.ptr());
     py::register_exception<simcoon::exception_solver>(m, "CppExceptionSolver", SimcoonError.ptr());
+
+    // Python-callback UMAT ('PYEXT'): StepCut, register/unregister/has_python_umat
+    init_pyumat(m);
 
     // Register the from-python converters for constitutive.hpp
     m.def("Ireal", &Ireal, "copy"_a = true, simcoon_docs::Ireal);

--- a/simcoon-python-builder/test/test_core/solver_harness.py
+++ b/simcoon-python-builder/test/test_core/solver_harness.py
@@ -97,3 +97,12 @@ def run_path(base_dir, umat_name, props, nstatev, corate, path_text):
         0.0, 0.0, 0.0, 0, corate, dd, rd, "path.txt", "res.txt",
     )
     return np.loadtxt(os.path.join(rd, "res_global-0.txt"), ndmin=2)
+
+
+def call_pyumat_batch(etot, Detot, sigma, DR, Wm, nstatev=0, time=0.5, dtime=1.0, **kw):
+    """``sim.umat("PYEXT", ...)`` on Fortran-ordered ``(., n)`` batches with empty F0/F1 and
+    props (the registered Python law holds its own parameters)."""
+    n = etot.shape[1]
+    return sim.umat("PYEXT", etot, Detot, np.array([]), np.array([]), sigma, DR,
+                    np.zeros((0, 1), order="F"), np.zeros((nstatev, n), order="F"),
+                    time, dtime, Wm, **kw)

--- a/simcoon-python-builder/test/test_core/test_doctor.py
+++ b/simcoon-python-builder/test/test_core/test_doctor.py
@@ -1,0 +1,36 @@
+"""simcoon.doctor: OpenMP runtime report (structure only; the verdict depends on the env)."""
+
+from simcoon import doctor
+
+
+def test_loaded_libraries_lists_this_process():
+    libs = doctor.loaded_libraries()
+    assert isinstance(libs, list)
+    if libs:                                   # unsupported platforms return []
+        assert any("numpy" in p or "python" in p.lower() or "libSystem" in p for p in libs)
+
+
+def test_collect_reports_imports_and_openmp_entries():
+    report = doctor.collect(modules=("numpy", "simcoon"))
+    assert "error" not in report, report.get("error")
+    assert [e["module"] for e in report["imports"]] == ["numpy", "simcoon"]
+    assert all(e["status"] == "ok" for e in report["imports"])
+    assert isinstance(report["openmp"], list)
+    for entry in report["openmp"]:
+        assert set(entry) == {"path", "brought_by"}
+    text = doctor.format_report(report)
+    assert "OpenMP runtimes loaded:" in text
+    assert ("OK:" in text) or ("PROBLEM:" in text)
+
+
+def test_format_report_advice_for_duplicates():
+    report = {
+        "python": "py", "platform": "darwin", "libraries": [],
+        "imports": [{"module": "simcoon", "status": "ok", "new_libraries": []},
+                    {"module": "torch", "status": "ok", "new_libraries": []}],
+        "openmp": [{"path": "/opt/x/libomp.dylib", "brought_by": "simcoon"},
+                   {"path": "/env/site-packages/torch/lib/libomp.dylib", "brought_by": "torch"}],
+        "blas": [],
+    }
+    text = doctor.format_report(report)
+    assert "PROBLEM" in text and "conda-forge pytorch" in text and "KMP_DUPLICATE_LIB_OK" in text

--- a/simcoon-python-builder/test/test_core/test_identify_metrics.py
+++ b/simcoon-python-builder/test/test_core/test_identify_metrics.py
@@ -1,0 +1,48 @@
+"""Metrics of simcoon.identify.calc_cost shared with simcoon.ml (mape, wmape, ...)."""
+
+import numpy as np
+import pytest
+
+from simcoon.identify import calc_cost
+
+
+def _data(seed=0):
+    rng = np.random.default_rng(seed)
+    y_exp = [rng.normal(size=(30, 2)) * 100 + 5, rng.normal(size=(20, 2)) * 50]
+    y_num = [y + rng.normal(size=y.shape) * 3 for y in y_exp]
+    return y_exp, y_num
+
+
+def test_wmape_definition():
+    y_exp, y_num = _data()
+    e = np.concatenate([y.ravel() for y in y_exp])
+    n = np.concatenate([y.ravel() for y in y_num])
+    expected = np.sum(np.abs(e - n)) / np.sum(np.abs(e))
+    assert calc_cost(y_exp, y_num, metric="wmape") == pytest.approx(expected, rel=1e-12)
+
+
+def test_wmape_weights():
+    y_exp, y_num = _data()
+    w_test = np.array([2.0, 0.5])
+    e0, e1 = y_exp[0].ravel(), y_exp[1].ravel()
+    n0, n1 = y_num[0].ravel(), y_num[1].ravel()
+    num = 2.0 * np.sum(np.abs(e0 - n0)) + 0.5 * np.sum(np.abs(e1 - n1))
+    den = 2.0 * np.sum(np.abs(e0)) + 0.5 * np.sum(np.abs(e1))
+    assert calc_cost(y_exp, y_num, w_test=w_test, metric="wmape") == pytest.approx(num / den, rel=1e-12)
+
+
+def test_mape_definition_matches_sklearn():
+    y_exp, y_num = _data()
+    e = np.concatenate([y.ravel() for y in y_exp])
+    n = np.concatenate([y.ravel() for y in y_num])
+    manual = np.mean(np.abs(e - n) / np.maximum(np.abs(e), np.finfo(np.float64).eps))
+    assert calc_cost(y_exp, y_num, metric="mape") == pytest.approx(manual, rel=1e-12)
+    skm = pytest.importorskip("sklearn.metrics")
+    assert calc_cost(y_exp, y_num, metric="mape") == pytest.approx(
+        skm.mean_absolute_percentage_error(e, n), rel=1e-12)
+
+
+def test_unknown_metric_lists_builtins():
+    y_exp, y_num = _data()
+    with pytest.raises((ValueError, ImportError), match="mape|scikit-learn"):
+        calc_cost(y_exp, y_num, metric="no_such_metric")

--- a/simcoon-python-builder/test/test_core/test_pyumat.py
+++ b/simcoon-python-builder/test/test_core/test_pyumat.py
@@ -1,0 +1,417 @@
+"""Tests for constitutive laws written in Python (PythonUMAT / 'PYEXT').
+
+A numpy law integrated by the C++ solver through the PYEXT callback must
+reproduce the equivalent built-in kernel (ELISO, EPICP) to round-off, under
+strain, stress and mixed control, including the tangent that feeds the Newton
+loop, step cuts and the batch entry point ``sim.umat``.
+"""
+
+import numpy as np
+import pytest
+
+import simcoon as sim
+from simcoon.solver import Block, StepMeca, solve
+from solver_harness import call_pyumat_batch
+
+E, NU = 70000.0, 0.3
+ELISO_PROPS = [E, NU, 1.0e-5]
+K_HARD = 1000.0
+SIGMA_Y = 300.0
+EPICP_LIN_PROPS = [E, NU, 1.0e-5, SIGMA_Y, K_HARD, 1.0]  # m = 1: linear isotropic hardening
+EPICP_NSTATEV = 8
+
+UNIAXIAL = ["strain"] + ["stress"] * 5
+
+
+def _voigt_stress_to_strain_form(v):
+    """Stress-like Voigt vector -> strain-like (engineering shear) Voigt vector."""
+    return v * np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0])
+
+
+# ---------------------------------------------------------------------------
+# Python laws used by the tests
+# ---------------------------------------------------------------------------
+
+class LinearElasticPy(sim.PythonUMAT):
+    """Linear isotropic elasticity; Wm bookkeeping identical to ELISO."""
+
+    nstatev = 0
+
+    def __init__(self, E=E, nu=NU):
+        self.L = sim.L_iso([E, nu], "Enu")
+        self.calls = 0
+
+    def integrate(self, *, Etot, DEtot, sigma, statev, Wm, ndi, **kw):
+        self.calls += 1
+        eps = Etot + DEtot
+        L = self.L
+        if ndi == 2:
+            # plane stress: static condensation on the out-of-plane direction (index 2),
+            # same algebra as el_pred(ndi=2) in constitutive.cpp
+            F = [0, 1, 3]
+            Q = np.zeros((6, 6))
+            Q[np.ix_(F, F)] = L[np.ix_(F, F)] - np.outer(L[F, 2], L[2, F]) / L[2, 2]
+            L = Q
+        stress = L @ eps
+        Wm = np.array(Wm, dtype=float)
+        Wm[0] += 0.5 * (sigma + stress) @ DEtot
+        Wm[1] = Wm[0]
+        return stress, L, statev, Wm
+
+
+class J2LinearPy(sim.PythonUMAT):
+    """J2 plasticity, linear isotropic hardening R = sigma_Y + k p, radial return with the
+    Simo-Hughes consistent tangent. statev = [p, EP(6)]."""
+
+    nstatev = 7
+
+    def __init__(self, E=E, nu=NU, sigma_y=SIGMA_Y, k=K_HARD):
+        self.L = sim.L_iso([E, nu], "Enu")
+        self.G = E / (2.0 * (1.0 + nu))
+        self.K = E / (3.0 * (1.0 - 2.0 * nu))
+        self.sigma_y = sigma_y
+        self.k = k
+        # projectors acting on STRAIN-like vectors (stiffness convention); the stress
+        # deviator below is taken directly (a stiffness projector would halve shear stresses)
+        self.Idev = sim.Tensor4.deviatoric("stiffness").mat
+        self.Ivol = sim.Tensor4.volumetric("stiffness").mat
+
+    def integrate(self, *, Etot, DEtot, sigma, statev, Wm, tangent_mode, **kw):
+        p = statev[0]
+        EP = statev[1:7]
+        eps = Etot + DEtot
+        L, G, k = self.L, self.G, self.k
+        sig_tr = L @ (eps - EP)
+        s_tr = sig_tr.copy()
+        s_tr[:3] -= sig_tr[:3].mean()                  # deviatoric trial stress (stress Voigt)
+        norm_s = np.sqrt(s_tr[:3] @ s_tr[:3] + 2.0 * (s_tr[3:] @ s_tr[3:]))
+        q_tr = np.sqrt(1.5) * norm_s
+        f = q_tr - (self.sigma_y + k * p)
+        Lt = L.copy()
+        stress = sig_tr
+        if f > 0.0:
+            dp = f / (3.0 * G + k)
+            n = s_tr / norm_s                          # unit deviatoric direction (tensor norm)
+            stress = sig_tr - 2.0 * G * dp * np.sqrt(1.5) * n
+            dEP = dp * np.sqrt(1.5) * _voigt_stress_to_strain_form(n)
+            EP = EP + dEP
+            p = p + dp
+            if tangent_mode != 0:
+                beta = 1.0 - 3.0 * G * dp / q_tr
+                gamma = 3.0 * G / (3.0 * G + k) - (1.0 - beta)
+                n_eps = _voigt_stress_to_strain_form(n)
+                Lt = 3.0 * self.K * self.Ivol + 2.0 * G * beta * self.Idev \
+                    - 2.0 * G * gamma * np.outer(n, n_eps)
+        Wm = np.array(Wm, dtype=float)
+        dW = 0.5 * (sigma + stress) @ DEtot
+        Wm[0] += dW
+        statev = np.concatenate([[p], EP])
+        return stress, Lt, statev, Wm, L
+
+
+class StepCutAbove(LinearElasticPy):
+    """Elastic law that refuses strain increments larger than a threshold."""
+
+    def __init__(self, threshold):
+        super().__init__()
+        self.threshold = threshold
+        self.cuts = 0
+
+    def integrate(self, *, DEtot, **kw):
+        if np.abs(DEtot).max() > self.threshold:
+            self.cuts += 1
+            raise sim.StepCut()
+        return super().integrate(DEtot=DEtot, **kw)
+
+
+def _assert_same(res_py, res_ref, rtol=1e-10, atol=1e-9, fields=("Stress", "Strain", "Wm")):
+    assert res_py.status == 0 and res_ref.status == 0
+    assert len(res_py) == len(res_ref)
+    for f in fields:
+        np.testing.assert_allclose(res_py[f], res_ref[f], rtol=rtol, atol=atol, err_msg=f)
+
+
+# ---------------------------------------------------------------------------
+# solve(): Python law vs built-in kernels
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("control", [
+    ["strain"] * 6,
+    UNIAXIAL,
+    ["stress"] * 6,
+])
+def test_linear_elastic_matches_eliso(control):
+    value = [0.01, -0.002, 0.001, 0.004, 0.0, -0.003] if control[1] == "strain" \
+        else [300.0, 0.0, 0.0, 50.0, 0.0, 0.0]
+    step = StepMeca(control=control, value=value, ninc=25)
+    res_py = solve(step, LinearElasticPy())
+    res_ref = solve(step, "ELISO", ELISO_PROPS, 1)
+    _assert_same(res_py, res_ref, fields=("Stress", "Strain", "Wm", "TangentMatrix"))
+    assert not sim._core.has_python_umat()      # context manager cleaned up
+
+
+def test_linear_elastic_cyclic_blocks_matches_eliso():
+    load = StepMeca(control=UNIAXIAL, value=[0.01, 0, 0, 0, 0, 0], ninc=20)
+    unload = StepMeca(control=UNIAXIAL, value=[-0.01, 0, 0, 0, 0, 0], ninc=20)
+    blocks = [Block(steps=[load, unload], ncycle=2)]
+    res_py = solve(blocks, LinearElasticPy())
+    res_ref = solve(blocks, "ELISO", ELISO_PROPS, 1)
+    _assert_same(res_py, res_ref, fields=("Stress", "Strain", "Wm", "TangentMatrix"))
+
+
+def test_linear_elastic_finite_strain_block_matches_eliso():
+    """Under NLGEOM the Python law is a log-strain / Kirchhoff box like ELISO
+    (kirchhoff_box membership): a missing entry would show up as a factor J."""
+    step = StepMeca(control=UNIAXIAL, value=[0.2, 0, 0, 0, 0, 0], ninc=20)
+    blocks = [Block(steps=[step], control_type="logarithmic")]
+    res_py = solve(blocks, LinearElasticPy())
+    res_ref = solve(blocks, "ELISO", ELISO_PROPS, 1)
+    _assert_same(res_py, res_ref, rtol=1e-9, atol=1e-7,
+                 fields=("Stress", "Strain", "Wm", "TangentMatrix", "F"))
+    assert abs(res_py["F"][0, 0, -1] - np.exp(0.2)) < 1e-6
+
+
+def test_j2_linear_hardening_matches_epicp():
+    load = StepMeca(control=UNIAXIAL, value=[0.02, 0, 0, 0, 0, 0], ninc=40)
+    rev = StepMeca(control=UNIAXIAL, value=[-0.02, 0, 0, 0, 0, 0], ninc=40)
+    blocks = [Block(steps=[load, rev], ncycle=2)]
+    res_py = solve(blocks, J2LinearPy())
+    res_ref = solve(blocks, "EPICP", EPICP_LIN_PROPS, EPICP_NSTATEV)
+    assert res_py.status == 0 and res_ref.status == 0
+    assert res_ref["Stress"][0].max() > SIGMA_Y * 1.1          # plasticity actually happened
+    np.testing.assert_allclose(res_py["Stress"], res_ref["Stress"], rtol=1e-8, atol=1e-6)
+    np.testing.assert_allclose(res_py["Strain"], res_ref["Strain"], rtol=1e-8, atol=1e-10)
+    np.testing.assert_allclose(res_py["Statev"][0], res_ref["Statev"][1], rtol=1e-8, atol=1e-12)
+    np.testing.assert_allclose(res_py["Statev"][1:7], res_ref["Statev"][2:8], rtol=1e-8, atol=1e-12)
+    np.testing.assert_allclose(res_py["Wm"][0], res_ref["Wm"][0], rtol=1e-8, atol=1e-6)
+    # consistent (Simo-Hughes) tangent
+    np.testing.assert_allclose(res_py["TangentMatrix"], res_ref["TangentMatrix"], rtol=1e-6, atol=1e-3)
+
+
+def test_j2_linear_hardening_matches_epicp_in_shear():
+    """Pure shear exercises the deviatoric/engineering-shear bookkeeping of the law."""
+    ctrl = ["stress", "stress", "stress", "strain", "stress", "stress"]
+    load = StepMeca(control=ctrl, value=[0, 0, 0, 0.03, 0, 0], ninc=30)
+    rev = StepMeca(control=ctrl, value=[0, 0, 0, -0.03, 0, 0], ninc=30)
+    res_py = solve([Block(steps=[load, rev])], J2LinearPy())
+    res_ref = solve([Block(steps=[load, rev])], "EPICP", EPICP_LIN_PROPS, EPICP_NSTATEV)
+    assert res_ref["Stress"][3].max() > SIGMA_Y / np.sqrt(3) * 1.02      # plastic in shear
+    np.testing.assert_allclose(res_py["Stress"], res_ref["Stress"], rtol=1e-8, atol=1e-6)
+    np.testing.assert_allclose(res_py["Statev"][0], res_ref["Statev"][1], rtol=1e-8, atol=1e-12)
+
+
+def test_props_and_nstatev_from_law_or_override():
+    law = LinearElasticPy()
+    step = StepMeca(control=UNIAXIAL, value=[0.01, 0, 0, 0, 0, 0], ninc=5)
+    res = solve(step, law)                          # props/nstatev from the object
+    assert res["Statev"].shape[0] == 0
+    res = solve(step, law, props=[1.0, 2.0], nstatev=3)   # explicit override
+    assert res["Statev"].shape[0] == 3
+    with pytest.raises(TypeError, match="props and nstatev"):
+        solve(step, "ELISO")
+
+
+# ---------------------------------------------------------------------------
+# step cut, errors
+# ---------------------------------------------------------------------------
+
+def test_step_cut_is_honored():
+    step = StepMeca(control=UNIAXIAL, value=[0.01, 0, 0, 0, 0, 0], ninc=10, Dn_mini=1e-3)
+    law = StepCutAbove(threshold=5.1e-4)            # 1e-3 per increment -> one cut each
+    res = solve(step, law)
+    assert res.status == 0
+    assert law.cuts >= 10
+    np.testing.assert_allclose(res["Stress"][0, -1], E * 0.01, rtol=1e-10)
+    np.testing.assert_allclose(res["Strain"][1, -1], -NU * 0.01, atol=1e-12)
+
+
+def test_step_cut_forever_aborts_without_inforce():
+    """inforce=0: the solver refuses to go below Dn_mini and aborts with status 1 (it used
+    to exit(0), killing the interpreter). The law is left unregistered afterwards."""
+    step = StepMeca(control=UNIAXIAL, value=[0.01, 0, 0, 0, 0, 0], ninc=5, Dn_mini=1e-2)
+    law = StepCutAbove(threshold=1e-9)              # cuts every genuine increment
+    res = solve(step, law, inforce=0, raise_on_abort=False)
+    assert res.status == 1 and len(res) == 0
+    with pytest.raises(RuntimeError, match="aborted early"):
+        solve(step, law, inforce=0)
+    assert law.cuts > 0
+    assert not sim._core.has_python_umat()
+
+
+class _BadShape(LinearElasticPy):
+    def integrate(self, **kw):
+        return np.zeros(5), np.eye(6), kw["statev"], kw["Wm"]
+
+
+class _BadCount(LinearElasticPy):
+    def integrate(self, **kw):
+        return np.zeros(6), np.eye(6), kw["statev"]
+
+
+class _Raises(LinearElasticPy):
+    def integrate(self, **kw):
+        return 1 / 0
+
+
+class _NonFinite(LinearElasticPy):
+    def integrate(self, **kw):
+        s = np.full(6, np.nan)
+        return s, np.eye(6), kw["statev"], kw["Wm"]
+
+
+@pytest.mark.parametrize("law, exc, match", [
+    (_BadShape(), ValueError, "sigma"),
+    (_BadCount(), ValueError, "4 or 5 return values"),
+    (_Raises(), ZeroDivisionError, "division"),
+    (_NonFinite(), ValueError, "non-finite"),
+])
+def test_errors_propagate_unchanged(law, exc, match):
+    step = StepMeca(control=UNIAXIAL, value=[0.01, 0, 0, 0, 0, 0], ninc=5)
+    with pytest.raises(exc, match=match):
+        solve(step, law)
+    assert not sim._core.has_python_umat()
+
+
+def test_no_registered_law_is_a_clear_error():
+    sim.pyumat.unregister()
+    step = StepMeca(control=UNIAXIAL, value=[0.01, 0, 0, 0, 0, 0], ninc=5)
+    with pytest.raises(RuntimeError, match="no UMAT callback"):
+        solve(step, "PYEXT", props=[], nstatev=0)
+
+
+def test_registered_restores_previous_law():
+    a, b = LinearElasticPy(), LinearElasticPy()
+    with sim.registered(a):
+        assert sim.pyumat.current() is a
+        with sim.registered(b):
+            assert sim.pyumat.current() is b
+        assert sim.pyumat.current() is a
+        assert sim._core.has_python_umat()
+    assert sim.pyumat.current() is None
+    assert not sim._core.has_python_umat()
+
+
+# ---------------------------------------------------------------------------
+# batch entry point sim.umat("PYEXT", ...)
+# ---------------------------------------------------------------------------
+
+def _batch_inputs(n, seed=0):
+    rng = np.random.default_rng(seed)
+    etot = np.asfortranarray(rng.normal(scale=1e-3, size=(6, n)))
+    Detot = np.asfortranarray(rng.normal(scale=1e-3, size=(6, n)))
+    sigma = np.asfortranarray(sim.L_iso([E, NU], "Enu") @ etot)
+    Wm = np.zeros((4, n), order="F")
+    DR = np.empty((3, 3, n), order="F")
+    DR[...] = np.eye(3)[:, :, None]
+    return etot, Detot, sigma, Wm, DR
+
+
+def test_batch_umat_matches_eliso_and_single_calls():
+    n = 250                                          # > parallel cutoff (100): serial branch
+    etot, Detot, sigma, Wm, DR = _batch_inputs(n)
+    law = LinearElasticPy()
+    with sim.registered(law):
+        out = call_pyumat_batch(etot, Detot, sigma, DR, Wm)
+    assert law.calls == n
+    ref = sim.umat("ELISO", etot, Detot, np.array([]), np.array([]), sigma, DR,
+                   np.asfortranarray(np.array(ELISO_PROPS)[:, None]),
+                   np.zeros((1, n), order="F"), 0.5, 1.0, Wm)
+    np.testing.assert_allclose(out[0], ref[0], rtol=1e-12, atol=1e-9)
+    np.testing.assert_allclose(out[3], ref[3], rtol=1e-12)
+    assert out[1].shape == (0, n)
+    # N single-point calls give the same columns
+    with sim.registered(law):
+        for pt in [0, 17, n - 1]:
+            col = lambda a: a[..., [pt]].copy(order="F")
+            one = call_pyumat_batch(col(etot), col(Detot), col(sigma), col(DR), col(Wm))
+            np.testing.assert_allclose(one[0][:, 0], out[0][:, pt], rtol=1e-12, atol=1e-9)
+
+
+def test_batch_umat_plane_stress_ndi2():
+    n = 3
+    etot, Detot, sigma, Wm, DR = _batch_inputs(n, seed=1)
+    etot[:] = 0.0
+    sigma[:] = 0.0
+    with sim.registered(LinearElasticPy()):
+        out = call_pyumat_batch(etot, Detot, sigma, DR, Wm, ndi=2)
+    Q = out[3][:, :, 0]
+    np.testing.assert_allclose(Q[0, 0], E / (1 - NU ** 2), rtol=1e-12)
+    np.testing.assert_allclose(Q[0, 1], NU * E / (1 - NU ** 2), rtol=1e-12)
+    np.testing.assert_allclose(Q[3, 3], E / (2 * (1 + NU)), rtol=1e-12)
+    assert np.all(Q[2, :] == 0.0) and np.all(Q[:, 2] == 0.0)
+    np.testing.assert_allclose(out[0][2], 0.0, atol=1e-12)     # sigma_33 = 0
+
+
+def test_batch_umat_step_cut_is_a_clear_error():
+    """The batch entry point cannot subdivide an increment: a StepCut must not be swallowed."""
+    n = 4
+    etot, Detot, sigma, Wm, DR = _batch_inputs(n)
+    with sim.registered(StepCutAbove(threshold=-1.0)):
+        with pytest.raises(RuntimeError, match="cannot subdivide"):
+            call_pyumat_batch(etot, Detot, sigma, DR, Wm)
+
+
+def test_batch_umat_stops_at_the_first_failing_point():
+    """A failing point aborts the batch instead of calling the law for the remaining ones."""
+    n = 20
+
+    class FailsAt(LinearElasticPy):
+        def __init__(self, at):
+            super().__init__()
+            self.at = at
+            self.points = 0
+
+        def integrate(self, **kw):
+            self.points += 1
+            if self.points > self.at:
+                raise ZeroDivisionError("boom")
+            return super().integrate(**kw)
+
+    etot, Detot, sigma, Wm, DR = _batch_inputs(n)
+    law = FailsAt(3)
+    with sim.registered(law):
+        with pytest.raises(ZeroDivisionError):
+            call_pyumat_batch(etot, Detot, sigma, DR, Wm)
+    assert law.points == 4                     # stopped at the failing point, not n
+
+
+def test_batch_umat_without_registration_is_a_clear_error():
+    sim.pyumat.unregister()
+    n = 2
+    etot, Detot, sigma, Wm, DR = _batch_inputs(n)
+    with pytest.raises(RuntimeError, match="no UMAT callback"):
+        call_pyumat_batch(etot, Detot, sigma, DR, Wm)
+
+
+def test_probe_call_leaves_statev_unchanged():
+    """The zero-increment tangent probe (DTime == 0, DEtot == 0) never advances statev."""
+
+    class Counter(sim.PythonUMAT):
+        nstatev = 1
+
+        def integrate(self, *, statev, Wm, sigma, **kw):
+            statev += 1.0                        # in place, on purpose
+            return sigma + 5.0, np.eye(6), statev, Wm + 1.0
+
+    law = Counter()
+    probe = dict(Etot=np.zeros(6), DEtot=np.zeros(6), sigma=np.ones(6), DR=np.eye(3),
+                 props=np.zeros(0), statev=np.zeros(1), T=293.15, DT=0.0, Time=0.0, DTime=0.0,
+                 Wm=np.zeros(4), ndi=3, nshr=3, start=True, tangent_mode=2)
+    out = law(**probe)
+    np.testing.assert_array_equal(out[0], np.ones(6))    # stress, statev and Wm untouched
+    assert out[2][0] == 0.0 and out[3][0] == 0.0
+    real = dict(probe, DEtot=np.array([1e-3, 0, 0, 0, 0, 0]), DTime=0.1, statev=np.zeros(1))
+    out = law(**real)
+    assert out[2][0] == 1.0 and out[0][0] == 6.0 and out[3][0] == 1.0
+
+
+def test_python_law_rejects_thermomechanical_blocks():
+    """select_umat_T has no PYEXT entry: say so in Python, not from deep inside the C++ solve."""
+    from simcoon.solver import StepThermomeca
+
+    step = StepThermomeca(control="stress", value=[0.0] * 6, ninc=5,
+                          thermal_control="heat_flux", Q=0.0)
+    with pytest.raises(TypeError, match="thermomechanical"):
+        solve(Block(steps=[step]), LinearElasticPy())
+    with pytest.raises(TypeError, match="thermomechanical"):
+        solve(step, LinearElasticPy())                 # bare step too

--- a/simcoon-python-builder/test/test_core/test_pyumat.py
+++ b/simcoon-python-builder/test/test_core/test_pyumat.py
@@ -128,7 +128,14 @@ def _assert_same(res_py, res_ref, rtol=1e-10, atol=1e-9, fields=("Stress", "Stra
     assert res_py.status == 0 and res_ref.status == 0
     assert len(res_py) == len(res_ref)
     for f in fields:
-        np.testing.assert_allclose(res_py[f], res_ref[f], rtol=rtol, atol=atol, err_msg=f)
+        ref = np.asarray(res_ref[f], dtype=float)
+        # The absolute tolerance has to follow the magnitude of the field. A stress component
+        # that is numerically zero sits next to components of 1e7 in the same array, and the
+        # two kernels reach it through a different order of floating-point operations (and,
+        # across platforms, a different BLAS): its residue is a few 1e-9, which is 1e-16 of
+        # the field and meaningless, but it defeats a fixed atol.
+        np.testing.assert_allclose(res_py[f], ref, rtol=rtol,
+                                   atol=atol + rtol * float(np.abs(ref).max()), err_msg=f)
 
 
 # ---------------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,6 +105,7 @@ target_sources(simcoon PRIVATE
   Continuum_mechanics/Umat/fea_transfer.cpp
   Continuum_mechanics/Umat/umat_L_elastic.cpp
   Continuum_mechanics/Umat/umat_smart.cpp
+  Continuum_mechanics/Umat/umat_callback.cpp
 
   # Simulation - Geometry
   Simulation/Geometry/cylinder.cpp

--- a/src/Continuum_mechanics/Umat/umat_callback.cpp
+++ b/src/Continuum_mechanics/Umat/umat_callback.cpp
@@ -1,0 +1,84 @@
+/* This file is part of simcoon.
+
+ simcoon is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ simcoon is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with simcoon.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+///@file umat_callback.cpp
+///@brief Process-wide callback slot served by the "PYEXT" UMAT name.
+
+#include <mutex>
+#include <utility>
+
+#include <simcoon/exception.hpp>
+#include <simcoon/Continuum_mechanics/Umat/umat_callback.hpp>
+
+namespace simcoon {
+
+namespace {
+
+// Function-local statics: no static-initialization-order issue, and the slot is never an
+// exported symbol (CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS only exports the accessor functions).
+std::mutex &cb_mutex() {
+    static std::mutex m;
+    return m;
+}
+
+umat_M_callback &cb_slot() {
+    static umat_M_callback cb;
+    return cb;
+}
+
+} // namespace
+
+void set_umat_callback(umat_M_callback cb) {
+    std::lock_guard<std::mutex> lock(cb_mutex());
+    cb_slot() = std::move(cb);
+}
+
+void clear_umat_callback() {
+    set_umat_callback(umat_M_callback{});
+}
+
+bool has_umat_callback() {
+    std::lock_guard<std::mutex> lock(cb_mutex());
+    return static_cast<bool>(cb_slot());
+}
+
+umat_M_callback get_umat_callback() {
+    std::lock_guard<std::mutex> lock(cb_mutex());
+    return cb_slot();
+}
+
+void umat_callback_M(const std::string &umat_name, const arma::vec &Etot, const arma::vec &DEtot,
+                     arma::vec &sigma, arma::mat &Lt, arma::mat &L, const arma::mat &DR,
+                     const int &nprops, const arma::vec &props, const int &nstatev, arma::vec &statev,
+                     const double &T, const double &DT, const double &Time, const double &DTime,
+                     double &Wm, double &Wm_r, double &Wm_ir, double &Wm_d,
+                     const int &ndi, const int &nshr, const bool &start, double &tnew_dt,
+                     const int &tangent_mode)
+{
+    // Snapshot under the lock, call outside it (the callback may take a long time).
+    umat_M_callback cb = get_umat_callback();
+    if (!cb) {
+        throw exception_solver(
+            "PYEXT: no UMAT callback registered. From Python, pass the law object to "
+            "simcoon.solver.solve(blocks, umat, ...) or wrap the call in "
+            "`with simcoon.registered(umat): ...`.");
+    }
+    cb(umat_name, Etot, DEtot, sigma, Lt, L, DR, nprops, props, nstatev, statev,
+       T, DT, Time, DTime, Wm, Wm_r, Wm_ir, Wm_d, ndi, nshr, start, tnew_dt, tangent_mode);
+}
+
+} // namespace simcoon

--- a/src/Continuum_mechanics/Umat/umat_smart.cpp
+++ b/src/Continuum_mechanics/Umat/umat_smart.cpp
@@ -59,6 +59,7 @@
 #include <simcoon/Continuum_mechanics/Umat/Mechanical/Viscoelasticity/Prony_Nfast.hpp>
 #include <simcoon/Continuum_mechanics/Umat/Modular/modular_umat.hpp>
 #include <simcoon/Continuum_mechanics/Umat/Modular/legacy_adapters.hpp>
+#include <simcoon/Continuum_mechanics/Umat/umat_callback.hpp>
 
 #include <simcoon/Continuum_mechanics/Umat/Thermomechanical/External/external_umat.hpp>
 #include <simcoon/Continuum_mechanics/Umat/Thermomechanical/Elasticity/elastic_isotropic.hpp>
@@ -193,7 +194,8 @@ bool stress_output_is_kirchhoff(const std::string &umat_name)
     static const std::set<std::string> kirchhoff_box = {
         "EPICP", "EPCHA", "MODUL",
         "ELISO", "ELIST", "ELORT", "EPKCP", "EPHIL", "EPTRI", "EPHAC",
-        "EPANI", "EPDFA", "EPCHG", "EPHIN"};
+        "EPANI", "EPDFA", "EPCHG", "EPHIN",
+        "PYEXT"};  // Python callback law: fed the log strain, returns tau (see umat_callback.hpp)
     return kirchhoff_box.count(umat_name) > 0;
 }
 
@@ -268,7 +270,7 @@ void select_umat_T(phase_characteristics &rve, const mat &DR_global,const double
 
 void select_umat_M_finite(phase_characteristics &rve, const mat &DR_global,const double &Time,const double &DTime, const int &ndi, const int &nshr, bool &start, const int &solver_type, const int &corate_type, double &tnew_dt)
 {
-    static const std::map<string, int> list_umat = {{"UMEXT",0},{"UMABA",1},{"ELISO",201},{"ELIST",201},{"ELORT",201},{"HYPOO",5},{"EPICP",6},{"EPCHA",7},{"EPKCP",201},{"SNTVE",8},{"NEOHI",9},{"NEOHC",10},{"MOORI",11},{"YEOHH",12},{"ISHAH",13},{"GETHH",14},{"SWANH",15},{"EPHIL",201},{"EPTRI",201},{"EPHAC",201},{"EPANI",201},{"EPDFA",201},{"EPCHG",201},{"EPHIN",201},{"MODUL",200},{"OGDEN",22}};
+    static const std::map<string, int> list_umat = {{"UMEXT",0},{"UMABA",1},{"ELISO",201},{"ELIST",201},{"ELORT",201},{"HYPOO",5},{"EPICP",6},{"EPCHA",7},{"EPKCP",201},{"SNTVE",8},{"NEOHI",9},{"NEOHC",10},{"MOORI",11},{"YEOHH",12},{"ISHAH",13},{"GETHH",14},{"SWANH",15},{"EPHIL",201},{"EPTRI",201},{"EPHAC",201},{"EPANI",201},{"EPDFA",201},{"EPCHG",201},{"EPHIN",201},{"MODUL",200},{"OGDEN",22},{"PYEXT",300}};
 
     // guarded lookup: operator[] would default-insert 0 (=UMEXT, a no-op) for an
     // unknown name and silently return zero stress; -1 falls to the default case
@@ -348,6 +350,13 @@ void select_umat_M_finite(phase_characteristics &rve, const mat &DR_global,const
             // EPICP (case 6) above. These were absent from this finite dispatcher, so a
             // missing-key lookup returned 0 and they silently fell through to case 0
             // (no-op) -> zero stress under NLGEOM. Registered here to fix that.
+            case 300: {
+                // PYEXT: process-wide callback UMAT (umat_callback.hpp; registered by the Python
+                // bindings). Small-strain convention on the log-strain / Kirchhoff box, as EPICP.
+                // NB the multi-name comment further up documents case 201, not this case.
+                umat_callback_M(rve.sptr_matprops->umat_name, umat_M->etot, umat_M->Detot, umat_M->sigma, umat_M->Lt, umat_M->L, DR, rve.sptr_matprops->nprops, rve.sptr_matprops->props, umat_M->nstatev, umat_M->statev, umat_M->T, umat_M->DT, Time, DTime, umat_M->Wm(0), umat_M->Wm(1), umat_M->Wm(2), umat_M->Wm(3), ndi, nshr, start, tnew_dt, umat_M->tangent_mode);
+                break;
+            }
             default: {
                 throw std::invalid_argument("Unknown umat name in the finite-strain dispatch: " + rve.sptr_matprops->umat_name);
             }
@@ -382,7 +391,7 @@ void select_umat_M_finite(phase_characteristics &rve, const mat &DR_global,const
 void select_umat_M(phase_characteristics &rve, const mat &DR_global,const double &Time,const double &DTime, const int &ndi, const int &nshr, bool &start, const int &solver_type, double &tnew_dt)
 {
 
-    static const std::map<string, int> list_umat = {{"UMEXT",0},{"UMABA",1},{"ELISO",201},{"ELIST",201},{"ELORT",201},{"EPICP",5},{"EPKCP",201},{"EPCHA",7},{"SMADI",8},{"SMADC",8},{"SMAAI",8},{"SMAAC",8},{"SMRDI",9},{"SMRDC",9},{"SMRAI",9},{"SMRAC",9},{"LLDM0",10},{"ZENER",11},{"ZENNK",12},{"PRONK",13},{"EPHIL",201},{"EPTRI",201},{"EPHAC",201},{"EPANI",201},{"EPDFA",201},{"EPCHG",201},{"EPHIN",201},{"SMAMO",23},{"SMAMC",24},{"MIHEN",100},{"MIMTN",101},{"MISCN",103},{"MIPLN",104},{"MODUL",200}};
+    static const std::map<string, int> list_umat = {{"UMEXT",0},{"UMABA",1},{"ELISO",201},{"ELIST",201},{"ELORT",201},{"EPICP",5},{"EPKCP",201},{"EPCHA",7},{"SMADI",8},{"SMADC",8},{"SMAAI",8},{"SMAAC",8},{"SMRDI",9},{"SMRDC",9},{"SMRAI",9},{"SMRAC",9},{"LLDM0",10},{"ZENER",11},{"ZENNK",12},{"PRONK",13},{"EPHIL",201},{"EPTRI",201},{"EPHAC",201},{"EPANI",201},{"EPDFA",201},{"EPCHG",201},{"EPHIN",201},{"SMAMO",23},{"SMAMC",24},{"MIHEN",100},{"MIMTN",101},{"MISCN",103},{"MIPLN",104},{"MODUL",200},{"PYEXT",300}};
 
     // Same frame handling as select_umat_M_finite: the caller's DR is global;
     // rotate it with the other state variables so the local UMAT receives the
@@ -491,6 +500,12 @@ void select_umat_M(phase_characteristics &rve, const mat &DR_global,const double
         }
         case 100: case 101: case 103: case 104: {
             umat_multi(rve, DR, Time, DTime, ndi, nshr, start, solver_type, tnew_dt, it_umat->second);
+            break;
+        }
+        case 300: {
+            // PYEXT: process-wide callback UMAT (umat_callback.hpp; registered by the Python
+            // bindings). Small-strain convention on the small-strain box, as EPICP.
+            umat_callback_M(rve.sptr_matprops->umat_name, umat_M->Etot, umat_M->DEtot, umat_M->sigma, umat_M->Lt, umat_M->L, DR, rve.sptr_matprops->nprops, rve.sptr_matprops->props, umat_M->nstatev, umat_M->statev, umat_M->T, umat_M->DT, Time, DTime, umat_M->Wm(0), umat_M->Wm(1), umat_M->Wm(2), umat_M->Wm(3), ndi, nshr, start, tnew_dt, umat_M->tangent_mode);
             break;
         }
         default: {

--- a/src/Simulation/Solver/solver.cpp
+++ b/src/Simulation/Solver/solver.cpp
@@ -199,6 +199,15 @@ int solver_run(std::vector<block> &blocks, const double &T_init, const solver_ou
 
                 //Run the umat for the first time in the block. So that we get the proper tangent properties
                 run_umat_M(rve, DR, Time, DTime, ndi, nshr, start, solver_type, blocks[i].control_type, corate_type, tnew_dt);
+                if (tnew_dt < 1.) {
+                    // Nothing to subdivide here (the increment is zero): the law refused the
+                    // priming call and Lt is still the zeros set a few lines above, which would
+                    // surface later as a singular Jacobian. Report the real cause.
+                    throw simcoon::exception_solver(
+                        "block " + std::to_string(i + 1) + ": the constitutive law requested a step "
+                        "cut on the zero-increment call that primes the tangent operator; no "
+                        "tangent could be obtained to start the block.");
+                }
                 
                 shared_ptr<step_meca> sptr_meca;
                 if(solver_type == 1) {
@@ -272,7 +281,9 @@ int solver_run(std::vector<block> &blocks, const double &T_init, const solver_ou
                             while (tinc<1.) {
                                 
                                 try {
-                                sptr_meca->compute_inc(tnew_dt, inc, tinc, Dtinc, Dtinc_cur, inforce_solver);
+                                if (!sptr_meca->compute_inc(tnew_dt, inc, tinc, Dtinc, Dtinc_cur, inforce_solver)) {
+                                    return 1; // increment below Dn_mini with inforce off
+                                }
                                                              
                                 if(nK == 0){
                                     
@@ -840,7 +851,9 @@ int solver_run(std::vector<block> &blocks, const double &T_init, const solver_ou
                             while (tinc<1.) {
 
                                 try {
-                                sptr_thermomeca->compute_inc(tnew_dt, inc, tinc, Dtinc, Dtinc_cur, inforce_solver);
+                                if (!sptr_thermomeca->compute_inc(tnew_dt, inc, tinc, Dtinc, Dtinc_cur, inforce_solver)) {
+                                    return 1; // increment below Dn_mini with inforce off
+                                }
                                 
                                 if(nK + sptr_thermomeca->cBC_T == 0){
                                     

--- a/src/Simulation/Solver/step.cpp
+++ b/src/Simulation/Solver/step.cpp
@@ -189,7 +189,7 @@ mat step::mode3_rows(const unsigned int &size_BC) const
 }
 
 //----------------------------------------------------------------------
-void step::compute_inc(double &tnew_dt, const int &inc, double &tinc, double &Dtinc, double &Dtinc_cur, const int &inforce_solver) {
+bool step::compute_inc(double &tnew_dt, const int &inc, double &tinc, double &Dtinc, double &Dtinc_cur, const int &inforce_solver) {
 //----------------------------------------------------------------------
     
     if((inc == 0)&&(Dtinc == 0.)){
@@ -206,8 +206,10 @@ void step::compute_inc(double &tnew_dt, const int &inc, double &tinc, double &Dt
             Dtinc_cur = Dn_mini;
         }
         else {
-//            cout << "\nThe increment size is less than the minimum specified\n";
-            exit(0);
+            // inforce_solver == 0: the caller asked NOT to force the minimal increment.
+            // Report it (not exit(0), which used to kill the host process silently): the
+            // solver aborts with status 1, like a non-converged Newton loop.
+            return false;
         }
         
     }
@@ -221,7 +223,7 @@ void step::compute_inc(double &tnew_dt, const int &inc, double &tinc, double &Dt
     if(tinc + Dtinc > 1.) {
         Dtinc = 1.-tinc;
     }
-    
+    return true;
 }
     
 /*!


### PR DESCRIPTION
A law implementing simcoon.PythonUMAT is registered under the name PYEXT for the duration of a call and integrated by the C++ material-point solver exactly like a built-in kernel: same 24-argument convention, same start-of-increment rollback (so all history must live in statev), same step-cut protocol (raise StepCut).

Core, free of Python: umat_callback.{hpp,cpp} holds the callback slot and the free function umat_callback_M, dispatched from select_umat_M and select_umat_M_finite under id 300. PYEXT joins kirchhoff_box, so the finite-strain dispatcher does not apply a second J factor to a small-strain box.

Bindings: pyumat.{hpp,cpp} bridges numpy and armadillo, re-acquires the GIL that solver_run releases, validates shapes and finiteness before committing anything to the caller's buffers, and maps StepCut onto tnew_dt. launch_umat serves PYEXT through a serial loop, the parallel helper forbidding Python in its region.

Solver: step::compute_inc now returns a status instead of calling exit(0), which killed the interpreter; its callers propagate it through the existing abort path.

Also in this layer: python -m simcoon.doctor reports the OpenMP runtimes actually loaded in the process, and simcoon.identify gains the mape and wmape metrics.
