### PR TITLE
Fix/inforce

### DIFF
--- a/include/simcoon/Simulation/Solver/solver.hpp
+++ b/include/simcoon/Simulation/Solver/solver.hpp
@@ -15,9 +15,6 @@
  
  */
 
-///@file solver.hpp
-///@brief To solver an homogeneous thermomechanical problem
-///@version 1.0
 
 #pragma once
 #include <armadillo>

--- a/include/simcoon/Simulation/Solver/solver_sink.hpp
+++ b/include/simcoon/Simulation/Solver/solver_sink.hpp
@@ -143,8 +143,19 @@ public:
  * @param corate_type Objective rate choice (see corate_kinematics, objective_rates.hpp)
  * @param ctrl Numeric solver controls
  * @param sink Results observer
- * @return 0 on completion, 1 on early abort (invalid solver type / unrecognized
- *         thermal BC / non-convergence with inforce == 0)
+ * @return 0 on completion, 1 on early abort. A run aborts on an invalid solver type, an
+ *         unrecognized thermal BC, a Newton loop that does not converge at the minimal
+ *         increment with @p inforce == 0, or a prescribed state the material cannot reach.
+ *
+ * The last case is the counterpart of the @p inforce contract. With @p inforce == 1 an
+ * increment that did not quite converge is closed anyway and its residual carried into the
+ * next one, which absorbs it. That is a correction, and it presumes the prescribed state is
+ * reachable: a stress target above the plateau of a perfectly plastic law, or above the
+ * saturation of a surrogate model, is not. The solver therefore watches whether the carried
+ * residual is actually being absorbed over consecutive increments, and aborts rather than
+ * closing the whole step on a state it never reached. The diagnostic reports the strain
+ * increment the tangent asks for, \f$ -\mathbf{K}^{-1}\mathbf{r} \f$, which diverges as the
+ * tangent collapses.
  */
 int solver_run(std::vector<block> &blocks, const double &T_init, const solver_output &so,
                const std::string &umat_name, const arma::vec &props, const unsigned int &nstatev,

--- a/simcoon-python-builder/test/test_core/test_solver_robustness.py
+++ b/simcoon-python-builder/test/test_core/test_solver_robustness.py
@@ -30,6 +30,10 @@ from simcoon.modular import (
     VonMisesYield,
     VoceHardening,
 )
+import numpy as np
+import pytest
+
+from simcoon.solver import Block, StepMeca, solve
 from solver_harness import C_TIME, S_STRESS, S_WM, path_file, run_path
 
 
@@ -68,3 +72,63 @@ def test_modul_voce_stress_unload_cycle(tmp_path):
 # resolves differently across LAPACK backends (completes on macOS, does not on
 # Linux/Windows). Asserting convergence there tests the platform, not the fix;
 # the modular Voce case above is the portable regression guard.
+
+
+# ---------------------------------------------------------------------------
+# a prescribed state the material cannot reach
+# ---------------------------------------------------------------------------
+
+E, NU, SIGMA_Y = 70000.0, 0.3, 300.0
+
+
+def _cycle(target, ninc):
+    """One stress-driven cycle to +/- target, two steps of unit duration."""
+    return [
+        Block(
+            steps=[
+                StepMeca(control=["stress"] * 6, value=[target, 0, 0, 0, 0, 0], ninc=ninc),
+                StepMeca(control=["stress"] * 6, value=[-target, 0, 0, 0, 0, 0], ninc=ninc),
+            ],
+            ncycle=1,
+        )
+    ]
+
+
+@pytest.mark.parametrize("ninc", [25, 100])
+def test_unreachable_stress_target_aborts_instead_of_reporting_success(ninc):
+    """A perfectly plastic law cannot be driven above its plateau.
+
+    ``inforce`` is a *correction*: it closes an increment that did not quite converge
+    and carries the residual into the next one, which absorbs it. When the target is
+    physically out of reach the residual is never absorbed, so that path used to close
+    every remaining increment and return status 0 on a state the run never reached --
+    with a time axis inflated by ``1/Dn_mini`` on top, because ``DTime`` was only
+    refreshed inside the branch that calls the UMAT.
+    """
+    props = [E, NU, 1.0e-5, SIGMA_Y, 0.0, 0.3]          # k = 0: no hardening
+    blocks = _cycle(2.0 * SIGMA_Y, ninc)                # far above the plateau
+
+    res = solve(blocks, "EPICP", props, 8, raise_on_abort=False)
+    assert res.status != 0, "an unreachable target must not be reported as converged"
+    # and the time axis stays inside the two unit-duration steps
+    assert float(np.asarray(res["Time"])[-1]) <= 2.0 + 1e-9
+    # the default contract turns that status into an exception
+    with pytest.raises(RuntimeError):
+        solve(blocks, "EPICP", props, 8)
+
+
+@pytest.mark.parametrize("ninc", [25, 100])
+def test_reachable_stress_target_is_unaffected(ninc):
+    """The guard must not disturb a target the material can reach.
+
+    Same cycle, once inside the plateau of the perfectly plastic law and once on a
+    hardening law that reaches it: both run to completion with an exact time axis.
+    """
+    for props, target in (
+        ([E, NU, 1.0e-5, SIGMA_Y, 0.0, 0.3], 0.8 * SIGMA_Y),      # below the plateau
+        ([E, NU, 1.0e-5, SIGMA_Y, 1000.0, 0.3], 2.0 * SIGMA_Y),   # hardening reaches it
+    ):
+        res = solve(_cycle(target, ninc), "EPICP", props, 8)
+        assert res.status == 0
+        assert float(np.asarray(res["Time"])[-1]) == pytest.approx(2.0, abs=1e-9)
+        assert res["Stress"][0, -1] == pytest.approx(-target, rel=1e-6)

--- a/src/Continuum_mechanics/Umat/umat_smart.cpp
+++ b/src/Continuum_mechanics/Umat/umat_smart.cpp
@@ -15,8 +15,9 @@
  */
 
 ///@file umat_smart.cpp
-///@brief Selection of constitutive laws and transfer to between Abaqus and simcoon formats
-///@brief Implemented in 1D-2D-3D
+///@file umat_smart.cpp
+///@brief Selection of constitutive laws and transfer between Abaqus and simcoon formats,
+///       implemented in 1D-2D-3D
 ///@version 1.0
 
 #include <iostream>
@@ -309,8 +310,12 @@ void select_umat_M_finite(phase_characteristics &rve, const mat &DR_global,const
                 break;
             }
             case 201: {
-                // Legacy names served by the modular engine on the log-strain
-                // measures (etot/Detot), exactly like EPICP above.
+                // Legacy names served by the modular engine on the log-strain measures
+                // (etot/Detot), exactly like EPICP above. The anisotropic-plasticity ones are
+                // corotational return-mapping models that transport their internal state by DR,
+                // so they integrate correctly under finite strain. They were absent from this
+                // finite dispatcher, so a missing-key lookup returned 0 and they silently fell
+                // through to case 0 (no-op) -> zero stress under NLGEOM.
                 umat_legacy_modular(rve.sptr_matprops->umat_name, umat_M->etot, umat_M->Detot, umat_M->sigma, umat_M->Lt, umat_M->L, DR, rve.sptr_matprops->nprops, rve.sptr_matprops->props, umat_M->nstatev, umat_M->statev, umat_M->T, umat_M->DT, Time, DTime, umat_M->Wm(0), umat_M->Wm(1), umat_M->Wm(2), umat_M->Wm(3), ndi, nshr, start, tnew_dt, umat_M->tangent_mode);
                 break;
             }
@@ -344,16 +349,9 @@ void select_umat_M_finite(phase_characteristics &rve, const mat &DR_global,const
                 umat_generic_hyper_pstretch(rve.sptr_matprops->umat_name, umat_M->etot, umat_M->Detot, umat_M->F0, umat_M->F1, umat_M->sigma, umat_M->Lt, umat_M->L, DR, rve.sptr_matprops->nprops, rve.sptr_matprops->props, umat_M->nstatev, umat_M->statev, umat_M->T, umat_M->DT, Time, DTime, umat_M->Wm(0), umat_M->Wm(1), umat_M->Wm(2), umat_M->Wm(3), ndi, nshr, start, tnew_dt, umat_M->tangent_mode);
                 break;
             }
-            // Anisotropic-plasticity UMATs: corotational return-mapping models that
-            // transport their internal state by DR, so they integrate correctly under
-            // finite strain on the logarithmic strain (umat_M->etot/Detot), exactly as
-            // EPICP (case 6) above. These were absent from this finite dispatcher, so a
-            // missing-key lookup returned 0 and they silently fell through to case 0
-            // (no-op) -> zero stress under NLGEOM. Registered here to fix that.
             case 300: {
                 // PYEXT: process-wide callback UMAT (umat_callback.hpp; registered by the Python
                 // bindings). Small-strain convention on the log-strain / Kirchhoff box, as EPICP.
-                // NB the multi-name comment further up documents case 201, not this case.
                 umat_callback_M(rve.sptr_matprops->umat_name, umat_M->etot, umat_M->Detot, umat_M->sigma, umat_M->Lt, umat_M->L, DR, rve.sptr_matprops->nprops, rve.sptr_matprops->props, umat_M->nstatev, umat_M->statev, umat_M->T, umat_M->DT, Time, DTime, umat_M->Wm(0), umat_M->Wm(1), umat_M->Wm(2), umat_M->Wm(3), ndi, nshr, start, tnew_dt, umat_M->tangent_mode);
                 break;
             }

--- a/src/Simulation/Solver/solver.cpp
+++ b/src/Simulation/Solver/solver.cpp
@@ -654,34 +654,14 @@ int solver_run(std::vector<block> &blocks, const double &T_init, const solver_ou
                                     }
                                     
                                 }
-/*                                if((fabs(Dtinc_cur - sptr_meca->Dn_mini) < simcoon::iota)&&(tnew_dt < 1.)) {
-//                                    cout << "The subroutine has required a step reduction lower than the minimal indicated at" << sptr_meca->number << " inc: " << inc << " and fraction:" << tinc << "\n";
-                                    //The solver has been inforced!
-                                    return;
-                                }
-                                
-                                if((error > 1000.*precision_solver)&&(Dtinc_cur == sptr_meca->Dn_mini)) {
-//                                    cout << "The error has exceeded 100 times the precision, the simulation has stopped at " << sptr_meca->number << " inc: " << inc << " and fraction:" << tinc << "\n";
-                                    //The solver has been inforced!
-                                    return;
-                                }*/
                                 
                                 if(error > precision_solver) {
                                     if(Dtinc_cur == sptr_meca->Dn_mini) {
                                         if(inforce_solver == 1) {
                                             
-                                            // The inforce path is a *correction*: it closes an increment
-                                            // that did not quite converge and carries the residual into
-                                            // the next one, which absorbs it. That only works if the
-                                            // prescribed state is reachable. When it is not - a stress
-                                            // target above the plateau of a perfectly plastic law, or
-                                            // above the saturation of a surrogate model - the residual is
-                                            // never absorbed, the path closes every remaining increment,
-                                            // and the run used to end with status 0 on a state it never
-                                            // reached. Delta = -invK*residual is the strain the Newton
-                                            // loop would need to close the gap; it diverges as the
-                                            // tangent collapses, which is what makes the target
-                                            // unreachable rather than merely hard.
+                                            // Give up when the carried residual is not being absorbed:
+                                            // the prescribed state is out of reach, not merely hard.
+                                            // Status protocol, never a throw (see solver_sink.hpp).
                                             if (n_inforced == 0) {
                                                 error_inforced = error;
                                             }
@@ -750,13 +730,10 @@ int solver_run(std::vector<block> &blocks, const double &T_init, const solver_ou
                                     step_cut_or_rethrow(Dtinc_cur, sptr_meca->Dn_mini, div_tnew_dt_solver, tnew_dt, compteur);
                                 }
 
-                                // DTime is otherwise only assigned inside the branch that assembles
-                                // and calls the UMAT. On the inforce path that branch is skipped while
-                                // Dtinc has shrunk to Dn_mini, so assess_inc used to add a stale
-                                // full-increment DTime once per forced sub-iteration, inflating Time by
-                                // 1/Dn_mini. Recompute it from the fraction actually being accepted;
-                                // every branch above uses this same expression, so this is a no-op
-                                // whenever one of them ran.
+                                // Every branch above assigns this same expression, but only when it
+                                // runs: the inforce path skips them while Dtinc has shrunk to Dn_mini,
+                                // and assess_inc would then add a stale full-increment DTime once per
+                                // forced sub-iteration. Recompute from the fraction actually accepted.
                                 DTime = Dtinc*sptr_meca->times(inc);
                                 sptr_meca->assess_inc(tnew_dt, tinc, Dtinc, rve ,Time, DTime, DR, corate_type);
                                 //start variables ready for the next increment

--- a/src/Simulation/Solver/solver.cpp
+++ b/src/Simulation/Solver/solver.cpp
@@ -57,6 +57,13 @@ namespace {
 // Single definition of the step-cut decision: bisect the increment unless it
 // is already at its minimal fraction. Returns whether the cut was applied —
 // call sites decide what a refusal means (throw a typed error, rethrow, ...).
+// How many increments in a row the inforce path may close before the prescribed state is
+// declared unreachable. A legitimate correction is isolated - one increment that did not quite
+// converge, whose residual the next one absorbs. A response saturated below the target stalls on
+// every increment instead. Deliberately generous, and it only bites when the error is *not*
+// decreasing, so a hard but converging problem is never interrupted.
+constexpr int inforce_stall_max = 5;
+
 inline bool try_step_cut(const double &Dtinc_cur, const double &Dn_mini,
                          const double &div_tnew_dt, double &tnew_dt) {
     if (fabs(Dtinc_cur - Dn_mini) > simcoon::iota) {
@@ -265,6 +272,11 @@ int solver_run(std::vector<block> &blocks, const double &T_init, const solver_ou
                         }
                     
                         nK = sum(sptr_meca->cBC_meca);
+                        
+                        // Bookkeeping of the "inforce" path over the step: how many increments in
+                        // a row it has closed, and the error it started from.
+                        int n_inforced = 0;
+                        double error_inforced = 0.;
                         
                         inc = 0;
                         while(inc < sptr_meca->ninc) {
@@ -658,6 +670,27 @@ int solver_run(std::vector<block> &blocks, const double &T_init, const solver_ou
                                     if(Dtinc_cur == sptr_meca->Dn_mini) {
                                         if(inforce_solver == 1) {
                                             
+                                            // The inforce path is a *correction*: it closes an increment
+                                            // that did not quite converge and carries the residual into
+                                            // the next one, which absorbs it. That only works if the
+                                            // prescribed state is reachable. When it is not - a stress
+                                            // target above the plateau of a perfectly plastic law, or
+                                            // above the saturation of a surrogate model - the residual is
+                                            // never absorbed, the path closes every remaining increment,
+                                            // and the run used to end with status 0 on a state it never
+                                            // reached. Delta = -invK*residual is the strain the Newton
+                                            // loop would need to close the gap; it diverges as the
+                                            // tangent collapses, which is what makes the target
+                                            // unreachable rather than merely hard.
+                                            if (n_inforced == 0) {
+                                                error_inforced = error;
+                                            }
+                                            n_inforced++;
+                                            if ((n_inforced > inforce_stall_max) && (error > 0.9 * error_inforced)) {
+                                                cout << "The prescribed state cannot be reached at step:" << sptr_meca->number << " inc: " << inc << ": inforced over " << n_inforced << " consecutive increments without absorbing the residual (error " << error << ", strain increment the tangent asks for: " << norm(Delta, 2.) << "). The material response is likely saturated below the target.\n";
+                                                return 1;
+                                            }
+                                            
                                             cout << "The solver has been inforced to proceed (Solver issue) at step:" << sptr_meca->number << " inc: " << inc << " and fraction:" << tinc << ", with the error: " << error << "\n";
 //                                            cout << "The next increment has integrated the error to avoid propagation\n";
                                             //The solver has been inforced!
@@ -691,6 +724,9 @@ int solver_run(std::vector<block> &blocks, const double &T_init, const solver_ou
                                         tnew_dt = div_tnew_dt_solver;
                                     }
                                 }
+                                else {
+                                    n_inforced = 0;   // converged: the inforce path is not stalling
+                                }
 
                                 if((compteur < miniter_solver)&&(tnew_dt >= 1.)) {
                                     tnew_dt = mul_tnew_dt_solver;
@@ -714,6 +750,14 @@ int solver_run(std::vector<block> &blocks, const double &T_init, const solver_ou
                                     step_cut_or_rethrow(Dtinc_cur, sptr_meca->Dn_mini, div_tnew_dt_solver, tnew_dt, compteur);
                                 }
 
+                                // DTime is otherwise only assigned inside the branch that assembles
+                                // and calls the UMAT. On the inforce path that branch is skipped while
+                                // Dtinc has shrunk to Dn_mini, so assess_inc used to add a stale
+                                // full-increment DTime once per forced sub-iteration, inflating Time by
+                                // 1/Dn_mini. Recompute it from the fraction actually being accepted;
+                                // every branch above uses this same expression, so this is a no-op
+                                // whenever one of them ran.
+                                DTime = Dtinc*sptr_meca->times(inc);
                                 sptr_meca->assess_inc(tnew_dt, tinc, Dtinc, rve ,Time, DTime, DR, corate_type);
                                 //start variables ready for the next increment
                                 


### PR DESCRIPTION
This pull request introduces a robust guard in the solver to correctly handle cases where the prescribed state in a simulation is physically unreachable (e.g., attempting to drive a perfectly plastic material above its yield plateau). Previously, the solver would incorrectly report success by closing all increments via the "inforce" path, even when the target could not be reached. The update ensures that the solver aborts and reports failure in such scenarios, and includes comprehensive regression tests to verify the fix. Additionally, some clarifications and code comments have been improved for maintainability.

**Solver robustness improvements:**

* Added logic to track consecutive increments closed via the "inforce" path and abort the run if the residual is not being absorbed, indicating the prescribed state is unreachable. This prevents silent false positives in solver status. [[1]](diffhunk://#diff-55e617d42f03d43053cff2234d924f3073559e63d0777e4e60d2ad48459cd43eR60-R66) [[2]](diffhunk://#diff-55e617d42f03d43053cff2234d924f3073559e63d0777e4e60d2ad48459cd43eR276-R280) [[3]](diffhunk://#diff-55e617d42f03d43053cff2234d924f3073559e63d0777e4e60d2ad48459cd43eL645-R673) [[4]](diffhunk://#diff-55e617d42f03d43053cff2234d924f3073559e63d0777e4e60d2ad48459cd43eR707-R709)
* Updated the solver's return value documentation to clarify the new abort condition and its relationship to the `inforce` contract.

**Testing enhancements:**

* Added regression tests in `test_solver_robustness.py` to verify that unreachable stress targets abort the solver instead of reporting success, and that reachable targets are unaffected. [[1]](diffhunk://#diff-8421f945c123dc7b4af10afac9ceb70df3f29ccd2347b7ec56ba84bc4ea4c07dR33-R36) [[2]](diffhunk://#diff-8421f945c123dc7b4af10afac9ceb70df3f29ccd2347b7ec56ba84bc4ea4c07dR75-R134)

**Code and documentation clarity:**

* Improved comments and documentation in the solver and UMAT dispatch logic to clarify the behavior and rationale for changes, including more precise explanations of legacy UMAT handling. [[1]](diffhunk://#diff-03ef71549ba6e9e10199b37799456e771cf2d29532cbe7ae49754989e31e7452L18-R20) [[2]](diffhunk://#diff-03ef71549ba6e9e10199b37799456e771cf2d29532cbe7ae49754989e31e7452L312-R318) [[3]](diffhunk://#diff-03ef71549ba6e9e10199b37799456e771cf2d29532cbe7ae49754989e31e7452L347-L356)

These changes collectively make the solver more reliable and transparent in reporting physically meaningful results.