### PR TITLE
Rename to_start -> set_start for state management

### DIFF
--- a/include/simcoon/Continuum_mechanics/Umat/Modular/internal_variable.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/internal_variable.hpp
@@ -264,11 +264,13 @@ public:
     // ========== State Management ==========
 
     /**
-     * @brief Copy current value to start value
+     * @brief Store the current value as the start-of-increment value.
      *
-     * Call at the beginning of an increment to save the state.
+     * Call at the beginning of an increment to save the state. Named after
+     * state_variables::set_start, which performs the same start <- current copy;
+     * to_start means the opposite (rollback) everywhere else in simcoon.
      */
-    void to_start();
+    void set_start();
 
     /**
      * @brief Apply rotation for objectivity

--- a/include/simcoon/Continuum_mechanics/Umat/Modular/internal_variable_collection.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/internal_variable_collection.hpp
@@ -171,7 +171,7 @@ public:
     /**
      * @brief Copy current values to start values for all variables
      */
-    void to_start_all();
+    void set_start_all();
 };
 
 } // namespace simcoon

--- a/include/simcoon/Continuum_mechanics/Umat/Modular/modular_umat.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/modular_umat.hpp
@@ -74,7 +74,7 @@ enum class DamageType;
  * orchestrator serializes the composed state as
  *   statev = [T_init | mechanism 0 | mechanism 1 | ...]
  * in composition order, by assigning each mechanism a base offset at
- * initialize() and delegating pack/unpack/rotate/to_start per mechanism.
+ * initialize() and delegating pack/unpack/rotate/set_start per mechanism.
  */
 class ModularUMAT {
 private:

--- a/include/simcoon/Continuum_mechanics/Umat/Modular/strain_mechanism.hpp
+++ b/include/simcoon/Continuum_mechanics/Umat/Modular/strain_mechanism.hpp
@@ -110,7 +110,7 @@ public:
     void rotate(const arma::mat& DR) { ivc_.rotate_all(DR); }
 
     /// Copy current values to start values for all owned variables.
-    void to_start() { ivc_.to_start_all(); }
+    void set_start() { ivc_.set_start_all(); }
 
     // ========== Configuration ==========
 

--- a/include/simcoon/Simulation/Phase/phase_characteristics.hpp
+++ b/include/simcoon/Simulation/Phase/phase_characteristics.hpp
@@ -126,13 +126,19 @@ class phase_characteristics
         virtual void sub_phases_construct(const int &shape_type, const int &sv_type, const int &n_sub);
         
         /**
-         * @brief Copy current values to start-of-increment values.
+         * @brief Reset the current values to the start-of-increment values.
+         *
+         * Rollback of a trial increment, applied to the global and local state
+         * variables of this phase and to every sub-phase.
          */
         virtual void to_start();
         
         /**
-         * @brief Set current values from start-of-increment values.
-         * @param control Control flag for selective update
+         * @brief Store the current values as the start-of-increment values.
+         *
+         * Acceptance of a converged increment, applied to the global and local state
+         * variables of this phase and to every sub-phase.
+         * @param control Corotational rate type, forwarded to the state variables.
          */
         virtual void set_start(const int &control);
         

--- a/include/simcoon/Simulation/Phase/state_variables.hpp
+++ b/include/simcoon/Simulation/Phase/state_variables.hpp
@@ -178,13 +178,22 @@ class state_variables
 		virtual int dimstatev () const {return nstatev;}
         
         /**
-         * @brief Copy current values to start-of-increment values.
+         * @brief Reset the current values to the start-of-increment values.
+         *
+         * Rollback: sets sigma = sigma_start, statev = statev_start, ... Called before
+         * every trial evaluation of the constitutive routine and when an increment is
+         * rejected (step cut), so that a trial never moves the state of the material.
          */
         virtual void to_start();
         
         /**
-         * @brief Set current values from start-of-increment values.
-         * @param control Control flag for selective update
+         * @brief Store the current values as the start-of-increment values.
+         *
+         * Acceptance of the increment: sets sigma_start = sigma, statev_start = statev,
+         * accumulates the total strain and temperature and advances the configuration
+         * (F0 = F1). Called once the increment has converged.
+         * @param control Corotational rate type, which selects how the accepted
+         * quantities are transported (see the implementation).
          */
         virtual void set_start(const int &control);
     

--- a/include/simcoon/Simulation/Phase/state_variables_M.hpp
+++ b/include/simcoon/Simulation/Phase/state_variables_M.hpp
@@ -70,8 +70,8 @@ class state_variables_M : public state_variables
 		
         using state_variables::update;
         virtual void update(const arma::vec &, const arma::vec &, const arma::vec &, const arma::vec &, const arma::vec &, const arma::vec &, const arma::vec &, const arma::vec &, const arma::vec &, const arma::vec &, const arma::mat &, const arma::mat &, const arma::mat &, const arma::mat &, const arma::mat &, const arma::mat &, const arma::vec &, const arma::vec &, const double &, const double &, const int &, const arma::vec &, const arma::vec &, const natural_basis &, const arma::vec &, const arma::vec &, const arma::mat &, const arma::mat &); //Initialize with parameters
-        virtual void to_start(); //Wm goes to Wm_start
-        virtual void set_start(const int &); //Wm_start goes to Wm
+        virtual void to_start(); //rollback: Wm_start goes to Wm
+        virtual void set_start(const int &); //accept: Wm goes to Wm_start
     
         using state_variables::rotate_l2g;
         virtual state_variables_M& rotate_l2g(const state_variables_M&, const double&, const double&, const double&);

--- a/include/simcoon/Simulation/Phase/state_variables_T.hpp
+++ b/include/simcoon/Simulation/Phase/state_variables_T.hpp
@@ -76,8 +76,8 @@ namespace simcoon{
 		
 		using state_variables::update;
 		virtual void update(const arma::vec &, const arma::vec &, const arma::vec &, const arma::vec &, const arma::vec &, const arma::vec &, const arma::vec &, const arma::vec &, const arma::vec &, const arma::vec &, const arma::mat &, const arma::mat &, const arma::mat &, const arma::mat &, const arma::mat &, const arma::mat &, const arma::vec &, const arma::vec &, const double &, const double &, const int &, const arma::vec &, const arma::vec &, const natural_basis &, const double &, const double &, const double &, const arma::vec &, const arma::vec &, const arma::vec &, const arma::vec &, const arma::mat &, const arma::mat &, const arma::mat &, const arma::mat &, const arma::mat &);
-        virtual void to_start(); //Wm & Wt goes to Wm_start & Wt_start, respectively
-        virtual void set_start(const int &); //Wm_start & Wt_start goes to Wm & Wt, respectively
+        virtual void to_start(); //rollback: Wm_start & Wt_start go to Wm & Wt, respectively
+        virtual void set_start(const int &); //accept: Wm & Wt go to Wm_start & Wt_start, respectively
     
         using state_variables::rotate_l2g;
         virtual state_variables_T& rotate_l2g(const state_variables_T&, const double&, const double&, const double&);

--- a/src/Continuum_mechanics/Umat/Modular/internal_variable.cpp
+++ b/src/Continuum_mechanics/Umat/Modular/internal_variable.cpp
@@ -205,7 +205,7 @@ arma::vec InternalVariable::delta_vec() const {
 
 // ========== State Management ==========
 
-void InternalVariable::to_start() {
+void InternalVariable::set_start() {
     switch (type_) {
         case IVarType::SCALAR:
             scalar_start_ = scalar_value_;

--- a/src/Continuum_mechanics/Umat/Modular/internal_variable_collection.cpp
+++ b/src/Continuum_mechanics/Umat/Modular/internal_variable_collection.cpp
@@ -136,9 +136,9 @@ void InternalVariableCollection::rotate_all(const arma::mat& DR) {
     }
 }
 
-void InternalVariableCollection::to_start_all() {
+void InternalVariableCollection::set_start_all() {
     for (auto& var : variables_) {
-        var.to_start();
+        var.set_start();
     }
 }
 

--- a/src/Continuum_mechanics/Umat/Modular/modular_umat.cpp
+++ b/src/Continuum_mechanics/Umat/Modular/modular_umat.cpp
@@ -307,7 +307,7 @@ void ModularUMAT::run(
     // Save start values
     sigma_start_ = sigma;
     for (auto& mech : mechanisms_) {
-        mech->to_start();
+        mech->set_start();
     }
 
     // Set elastic stiffness

--- a/test/Libraries/Umat/Modular/Tmodular_umat.cpp
+++ b/test/Libraries/Umat/Modular/Tmodular_umat.cpp
@@ -124,7 +124,7 @@ TEST_F(InternalVariableTest, VectorPackUnpack) {
 
 TEST_F(InternalVariableTest, DeltaComputation) {
     InternalVariable iv("test", 1.0);
-    iv.to_start();  // Save current as start
+    iv.set_start();  // Save current as start
 
     iv.scalar() = 3.0;  // Modify
     EXPECT_DOUBLE_EQ(iv.delta_scalar(), 2.0);
@@ -153,10 +153,10 @@ TEST_F(InternalVariableTest, TensorViews) {
     EXPECT_EQ(L_t.type(), Tensor4Type::stiffness);
     EXPECT_LT(arma::norm(arma::mat(L_t.mat()) - L_init, "fro"), 1e-10);
 
-    // Typed START views: after to_start + a further mutation, as_tensor2()
+    // Typed START views: after set_start + a further mutation, as_tensor2()
     // sees the current value while as_tensor2_start() reconstructs the
     // start-of-increment state with the variable's own vtype.
-    EP.to_start();
+    EP.set_start();
     arma::vec newer_EP = {0.03, -0.015, -0.015, 0.006, 0.0, 0.0};
     EP.set_tensor2(tensor2::from_voigt(newer_EP, Tensor2Type::strain));
     EXPECT_EQ(EP.as_tensor2_start().vtype(), Tensor2Type::strain);
@@ -1522,7 +1522,7 @@ TEST(ModularUMATTangent, RefreshStateBackwardEulerAF) {
     // Non-trivial start state.
     ivc.get("p").scalar() = 0.01;
     ivc.get("a").raw_voigt() = vec{0.002, -0.001, -0.001, 0.0005, 0.0, 0.0};
-    ivc.to_start_all();
+    ivc.set_start_all();
 
     const vec sigma = {400.0, 50.0, -30.0, 60.0, 10.0, 0.0};
     const double dp = 5.0e-3;


### PR DESCRIPTION
Rename internal state-management API from to_start to set_start across the UMAT modular code to unify naming and clarify semantics (store current values as start-of-increment / accept increment). Updated declarations/definitions in InternalVariable, InternalVariableCollection and ModularUMAT, adjusted callers (e.g. strain_mechanism) and corresponding tests. Also improved doc comments in phase/state variable headers to distinguish rollback (to_start) vs acceptance (set_start) behavior. No functional logic changes beyond the API rename and documentation/test updates.