### PR TITLE
Fetch pinned carma release by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,8 +243,15 @@ if(BUILD_PYTHON_BINDINGS)
   find_package(Python3 COMPONENTS Interpreter Development.Module NumPy REQUIRED)
   find_package(pybind11 REQUIRED)
 
+  # pip/uv builds set SIMCOON_FETCH_CARMA (pyproject.toml) so every wheel and editable
+  # install uses the pinned release fetched below, never a carma that happens to be on
+  # the machine (e.g. another conda environment's). The conda recipe keeps its own.
+  option(SIMCOON_FETCH_CARMA "Always fetch the pinned carma release instead of searching for one" OFF)
+
   # Try to find carma from conda/system first
-  find_package(carma CONFIG QUIET)
+  if(NOT SIMCOON_FETCH_CARMA)
+    find_package(carma CONFIG QUIET)
+  endif()
 
   if(carma_FOUND)
     message(STATUS "Found carma package (CONFIG mode)")
@@ -265,7 +272,7 @@ if(BUILD_PYTHON_BINDINGS)
       set(CONDA_PREFIX $ENV{CONDA_PREFIX})
     endif()
 
-    if(CONDA_PREFIX AND EXISTS "${CONDA_PREFIX}/include/carma")
+    if(NOT SIMCOON_FETCH_CARMA AND CONDA_PREFIX AND EXISTS "${CONDA_PREFIX}/include/carma")
       message(STATUS "Found carma headers in conda environment")
       set(carma_INCLUDE_DIR "${CONDA_PREFIX}/include")
 
@@ -274,16 +281,21 @@ if(BUILD_PYTHON_BINDINGS)
         add_library(carma::carma INTERFACE IMPORTED)
         set_target_properties(carma::carma PROPERTIES
           INTERFACE_INCLUDE_DIRECTORIES "${carma_INCLUDE_DIR}"
+          INTERFACE_LINK_LIBRARIES Python3::NumPy
         )
       endif()
       set(carma_FOUND TRUE)
     else()
       # Fall back to fetching from GitHub
-      message(STATUS "carma not found, fetching from GitHub")
+      message(STATUS "carma: fetching the pinned release v0.8.0 from GitHub")
       FetchContent_Declare(
         carma
         GIT_REPOSITORY https://github.com/RUrlus/carma.git
         GIT_TAG        v0.8.0
+        # Headers only (no CMakeLists.txt there): carma's own project fetches a second
+        # Armadillo (12.8.x) and puts it ahead of the one simcoon is built with, so _core
+        # and libsimcoon would exchange arma objects across two Armadillo versions.
+        SOURCE_SUBDIR  include
       )
       FetchContent_MakeAvailable(carma)
 
@@ -296,6 +308,7 @@ if(BUILD_PYTHON_BINDINGS)
         add_library(carma::carma INTERFACE IMPORTED)
         set_target_properties(carma::carma PROPERTIES
           INTERFACE_INCLUDE_DIRECTORIES "${carma_INCLUDE_DIR}"
+          INTERFACE_LINK_LIBRARIES Python3::NumPy
         )
       endif()
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,7 +281,7 @@ if(BUILD_PYTHON_BINDINGS)
         add_library(carma::carma INTERFACE IMPORTED)
         set_target_properties(carma::carma PROPERTIES
           INTERFACE_INCLUDE_DIRECTORIES "${carma_INCLUDE_DIR}"
-          INTERFACE_LINK_LIBRARIES Python3::NumPy
+          INTERFACE_LINK_LIBRARIES "Python3::NumPy;pybind11::headers"
         )
       endif()
       set(carma_FOUND TRUE)
@@ -303,12 +303,14 @@ if(BUILD_PYTHON_BINDINGS)
       FetchContent_GetProperties(carma SOURCE_DIR carma_SOURCE_DIR)
       set(carma_INCLUDE_DIR "${carma_SOURCE_DIR}/include")
 
-      # Ensure carma::carma target exists with proper include directories
+      # Ensure carma::carma target exists with proper include directories. carma headers
+      # include pybind11 and numpy, and on Windows libsimcoon (which has no pybind11 of its
+      # own) force-includes cnalloc.h, so both have to come with the target.
       if(NOT TARGET carma::carma)
         add_library(carma::carma INTERFACE IMPORTED)
         set_target_properties(carma::carma PROPERTIES
           INTERFACE_INCLUDE_DIRECTORIES "${carma_INCLUDE_DIR}"
-          INTERFACE_LINK_LIBRARIES Python3::NumPy
+          INTERFACE_LINK_LIBRARIES "Python3::NumPy;pybind11::headers"
         )
       endif()
     endif()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,10 @@ install.components = ["python"]
 
 [tool.scikit-build.cmake.define]
 SIMCOON_BUILD_TESTS = "OFF"
+# Always build against the pinned carma release fetched by CMake: carma is not on PyPI
+# (the "carma" package there is unrelated), and a carma found elsewhere on the machine
+# may differ. The conda recipe calls CMake directly and keeps its own carma dependency.
+SIMCOON_FETCH_CARMA = "ON"
 
 # =============================================================================
 # pytest configuration

--- a/simcoon-python-builder/test/test_core/test_lt_convert_memory.py
+++ b/simcoon-python-builder/test/test_core/test_lt_convert_memory.py
@@ -1,0 +1,84 @@
+"""Batched Lt_convert must not leak memory.
+
+Each point builds a 6x6 tangent inside libsimcoon that is freed in the _core
+extension. The two modules do not share an allocator on Windows (Armadillo's
+_aligned_malloc vs carma's numpy allocator), so a silently refused free would
+show up here as memory growth proportional to the number of points.
+"""
+
+import ctypes
+import gc
+import os
+import sys
+
+import numpy as np
+import pytest
+
+import simcoon as sim
+
+
+def _memory_bytes():
+    """Private memory (Windows), resident set (Linux) or peak resident set (macOS)."""
+    if sys.platform == "win32":
+        class ProcessMemoryCounters(ctypes.Structure):
+            _fields_ = [
+                ("cb", ctypes.c_ulong),
+                ("PageFaultCount", ctypes.c_ulong),
+                ("PeakWorkingSetSize", ctypes.c_size_t),
+                ("WorkingSetSize", ctypes.c_size_t),
+                ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),
+                ("QuotaPagedPoolUsage", ctypes.c_size_t),
+                ("QuotaPeakNonPagedPoolUsage", ctypes.c_size_t),
+                ("QuotaNonPagedPoolUsage", ctypes.c_size_t),
+                ("PagefileUsage", ctypes.c_size_t),
+                ("PeakPagefileUsage", ctypes.c_size_t),
+                ("PrivateUsage", ctypes.c_size_t),
+            ]
+
+        counters = ProcessMemoryCounters()
+        counters.cb = ctypes.sizeof(ProcessMemoryCounters)
+        kernel32 = ctypes.WinDLL("kernel32")
+        psapi = ctypes.WinDLL("psapi")
+        kernel32.GetCurrentProcess.restype = ctypes.c_void_p
+        psapi.GetProcessMemoryInfo.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_ulong]
+        if not psapi.GetProcessMemoryInfo(kernel32.GetCurrentProcess(), ctypes.byref(counters), counters.cb):
+            pytest.skip("GetProcessMemoryInfo failed")
+        return counters.PrivateUsage
+    if sys.platform.startswith("linux"):
+        with open("/proc/self/statm") as statm:
+            return int(statm.read().split()[1]) * os.sysconf("SC_PAGE_SIZE")
+    if sys.platform == "darwin":
+        import resource
+
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss  # bytes on macOS
+    pytest.skip("no memory probe on this platform")
+
+
+def test_batched_lt_convert_does_not_leak():
+    n_points, calls = 1000, 100
+    rng = np.random.default_rng(0)
+    F = (np.tile(np.eye(3)[:, :, None], (1, 1, n_points))
+         + 0.02 * rng.standard_normal((3, 3, n_points))).copy(order="F")
+    stress = np.asfortranarray(rng.standard_normal((6, n_points)))
+    L = np.asarray(sim.L_iso([70000.0, 0.3], "Enu"))
+    Lt = np.asfortranarray(np.tile(L[:, :, None], (1, 1, n_points)))
+
+    def fedoo_pair():
+        # fedoo's stress_equilibrium: box tangent -> dS/dE, then -> dsigma/dD
+        dsde = sim.Lt_convert(Lt, F, stress, "DsigmaDe_2_DSDE")
+        sim.Lt_convert(dsde, F, stress, "DSDE_2_Dsigma_logarithmicDD")
+
+    for _ in range(10):
+        fedoo_pair()
+    gc.collect()
+    start = _memory_bytes()
+    for _ in range(calls):
+        fedoo_pair()
+    gc.collect()
+    growth = _memory_bytes() - start
+
+    leaked_if_leaking = 2 * calls * n_points * 36 * 8
+    assert growth < 0.2 * leaked_if_leaking, (
+        f"memory grew by {growth / 2**20:.1f} MB over {calls} batched calls; "
+        f"leaking every per-point tangent would add {leaked_if_leaking / 2**20:.0f} MB"
+    )


### PR DESCRIPTION
Add a SIMCOON_FETCH_CARMA option and enable it for pip builds so installers always use the pinned carma release instead of any carma found on the machine. When enabled, CMake skips find_package(carma) and conda header detection and instead FetchContent_Declares carma@v0.8.0 using SOURCE_SUBDIR=include to avoid pulling a second Armadillo. Also ensure the imported carma::carma target propagates Python3::NumPy via INTERFACE_LINK_LIBRARIES. The pyproject.toml scikit-build define sets SIMCOON_FETCH_CARMA=ON so pip/uv wheels and editable installs follow this behavior.