### PR TITLE
Update modular_python.rst

### DIFF
--- a/docs/simulation/modular_python.rst
+++ b/docs/simulation/modular_python.rst
@@ -222,9 +222,10 @@ Tangent operator and finite strain
 ``MODUL`` honors the solver's ``tangent_mode`` (continuum or algorithmic,
 algorithmic being the 2.0 default — :doc:`solver`). Under the finite-strain
 control types the composition acts as a Hencky hyperelastic law on the
-logarithmic strain and requires ``corate_type = 3`` (log_R): pass
-``corate="logarithmic_R"`` to :func:`simcoon.solver.solve` — the default
-``corate="logarithmic"`` is the XBM rate (code 2).
+logarithmic strain and requires ``corate_type = 3`` (log_R) — which is the
+:func:`simcoon.solver.solve` default, so nothing needs to be passed. Any
+other corate (e.g. ``corate="logarithmic"``, the XBM rate, code 2) is
+rejected under NLGEOM.
 
 See also
 --------


### PR DESCRIPTION
This pull request updates the documentation for the tangent operator and finite strain section to clarify the default behavior and requirements for `corate_type` when using finite-strain control types with `MODUL`. The update removes outdated instructions and explains that the correct `corate_type` is now the default, improving clarity for users.

Documentation improvements:

* Updated the explanation for `corate_type` under finite-strain control types to state that `corate_type = 3` (log_R) is now the default in `:func:simcoon.solver.solve`, so no explicit argument is needed. Also clarified that other corates (such as `corate="logarithmic"`, code 2) are rejected under NLGEOM.